### PR TITLE
Changes for More Complex XMS Libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = []
 version = __version__
 
 setup(
-    python_requires='>=3.10',
+    python_requires='>=3.6',
     name='xmsconan',
     version=version,
     packages=['xmsconan'],

--- a/xmsconan/build_helpers.py
+++ b/xmsconan/build_helpers.py
@@ -31,7 +31,6 @@ def get_builder(library_name):
         # General Options
         env_vars.update({
             'XMS_VERSION': xms_version,
-            'VERBOSE': 1,
             'PYTHON_TARGET_VERSION': python_target_version,
             'RELEASE_PYTHON': release_python,
             'AQUAPI_USERNAME': aquapi_username,

--- a/xmsconan/build_helpers.py
+++ b/xmsconan/build_helpers.py
@@ -31,6 +31,7 @@ def get_builder(library_name):
         # General Options
         env_vars.update({
             'XMS_VERSION': xms_version,
+            'VERBOSE': 1,
             'PYTHON_TARGET_VERSION': python_target_version,
             'RELEASE_PYTHON': release_python,
             'AQUAPI_USERNAME': aquapi_username,

--- a/xmsconan/xms_conan_file.py
+++ b/xmsconan/xms_conan_file.py
@@ -77,7 +77,7 @@ class XmsConanFile(ConanFile):
                                  'Visual Studio')
 
         self.options['boost'].wchar_t = self.options.wchar_t
-        
+
         for dependency in self.xms_dependencies:
             dep_name, _, _ = dependency.split('/')
             self.options[dep_name].pybind = self.options.pybind
@@ -203,7 +203,7 @@ class XmsConanFile(ConanFile):
         """
         self.copy('*', src=f'{self.name}', dst=f'{self.name}')
         self.copy('*', src='_package', dst='_package')
-        
+
         for item in self.extra_export_sources:
             self.copy('*', src=f'{item}', dst=f'{item}')
 
@@ -213,6 +213,6 @@ class XmsConanFile(ConanFile):
         """
         self.copy('CMakeLists.txt')
         self.copy('LICENSE')
-        
+
         for item in self.extra_exports:
             self.copy(f'{item}')

--- a/xmsconan/xms_conan_file.py
+++ b/xmsconan/xms_conan_file.py
@@ -209,7 +209,6 @@ class XmsConanFile(ConanFile):
                 self.copy('*', src=f'{item}', dst=f'{item}')
             else:
                 self.copy(f'{item}')
-                
 
     def export(self):
         """

--- a/xmsconan/xms_conan_file.py
+++ b/xmsconan/xms_conan_file.py
@@ -205,7 +205,11 @@ class XmsConanFile(ConanFile):
         self.copy('*', src='_package', dst='_package')
 
         for item in self.extra_export_sources:
-            self.copy('*', src=f'{item}', dst=f'{item}')
+            if os.path.isdir(item):
+                self.copy('*', src=f'{item}', dst=f'{item}')
+            else:
+                self.copy(f'{item}')
+                
 
     def export(self):
         """
@@ -215,4 +219,7 @@ class XmsConanFile(ConanFile):
         self.copy('LICENSE')
 
         for item in self.extra_exports:
-            self.copy(f'{item}')
+            if os.path.isdir(item):
+                self.copy('*', src=f'{item}', dst=f'{item}')
+            else:
+                self.copy(f'{item}')

--- a/xmsconan/xms_conan_file.py
+++ b/xmsconan/xms_conan_file.py
@@ -20,6 +20,9 @@ class XmsConanFile(ConanFile):
     }
     generators = "cmake", "txt"
     build_requires = "cxxtest/4.4@aquaveo/stable"
+    xms_dependencies = []
+    extra_exports = []
+    extra_export_sources = []
 
     default_options = {
         'wchar_t': 'builtin',
@@ -77,9 +80,9 @@ class XmsConanFile(ConanFile):
         
         for dependency in self.xms_dependencies:
             dep_name, _, _ = dependency.split('/')
-            self.options[dep_name].pybind = self.option.pybind
-            self.options[dep_name].testing = self.option.testing
-            self.options[dep_name].wchar_t = self.option.wchar_t
+            self.options[dep_name].pybind = self.options.pybind
+            self.options[dep_name].testing = self.options.testing
+            self.options[dep_name].wchar_t = self.options.wchar_t
 
     def build(self):
         """
@@ -136,7 +139,7 @@ class XmsConanFile(ConanFile):
         A function to run the cxx_tests.
         """
         try:
-            cmake.test()
+            cmake.test(output_on_failure=True)
         except ConanException:
             raise
         finally:
@@ -198,9 +201,11 @@ class XmsConanFile(ConanFile):
         """
         Specify sources to be exported.
         """
-        self.output.info('----- RUNNING EXPORT_SOURCES()')
         self.copy('*', src=f'{self.name}', dst=f'{self.name}')
         self.copy('*', src='_package', dst='_package')
+        
+        for item in self.extra_export_sources:
+            self.copy('*', src=f'{item}', dst=f'{item}')
 
     def export(self):
         """
@@ -208,3 +213,6 @@ class XmsConanFile(ConanFile):
         """
         self.copy('CMakeLists.txt')
         self.copy('LICENSE')
+        
+        for item in self.extra_exports:
+            self.copy(f'{item}')

--- a/xmsconan/xms_conan_file.py
+++ b/xmsconan/xms_conan_file.py
@@ -74,6 +74,12 @@ class XmsConanFile(ConanFile):
                                  'Visual Studio')
 
         self.options['boost'].wchar_t = self.options.wchar_t
+        
+        for dependency in self.xms_dependencies:
+            dep_name, _, _ = dependency.split('/')
+            self.options[dep_name].pybind = self.option.pybind
+            self.options[dep_name].testing = self.option.testing
+            self.options[dep_name].wchar_t = self.option.wchar_t
 
     def build(self):
         """


### PR DESCRIPTION
Additions:
- Change required python from 3.10 to 3.6
- ~~Verbose environment variable for more verbose output~~
- `xms_dependencies` list for adding different dependencies for libraries
- `extra_exports` list for adding different exports for libraries
- Argument to `cmake.test()` to produce output even if it fails
- Set options of dependencies