### PR TITLE
Fix python tests and allow arm builds.

### DIFF
--- a/xmsconan/build_helpers.py
+++ b/xmsconan/build_helpers.py
@@ -78,7 +78,7 @@ def get_builder(library_name):
     pybind_updated_builds = []
     for settings, options, env_vars, build_requires, _ in builder.items:
         # Pybind builds are built for 64-bit, non-debug MD(d) builds.
-        if settings['arch'] == 'x86_64' and settings['build_type'] != 'Debug' and \
+        if settings['build_type'] != 'Debug' and \
            (settings['compiler'] != 'Visual Studio' or settings['compiler.runtime'] in ['MD', 'MDd']):
             # Pybind is only built for visual studio versions greater than 12.
             if settings['compiler'] == 'Visual Studio' and int(settings['compiler.version']) <= 12:

--- a/xmsconan/xms_conan_file.py
+++ b/xmsconan/xms_conan_file.py
@@ -162,7 +162,7 @@ class XmsConanFile(ConanFile):
 
             # Run python tests.
             path_to_python_tests = os.path.join(
-                self.build_folder, '_package', 'tests')
+                self.source_folder, '_package', 'tests')
             self.run(f'python -m unittest discover -v -p *_pyt.py -s {path_to_python_tests}',
                      cwd=os.path.join(self.package_folder, "_package"))
 


### PR DESCRIPTION
- Fixed python tests to work when going through conan package development steps one-by-one.
- Removed architecture check from pybind builds to allow armv8 builds on macOS.