### PR TITLE
Added an option for using auto set plat name.

### DIFF
--- a/xmsconan/__init__.py
+++ b/xmsconan/__init__.py
@@ -1,4 +1,4 @@
 """
 Methods and Modules used to aid in xmsconan projects.
 """
-__version__ = '1.0.3'
+__version__ = '1.0.4'

--- a/xmsconan/xms_conan_file.py
+++ b/xmsconan/xms_conan_file.py
@@ -189,10 +189,7 @@ class XmsConanFile(ConanFile):
         self.run('devpi use {}'.format(devpi_url))
         self.run(
             'devpi login {} --password {}'.format(devpi_username, devpi_password))
-        plat_names = {'Windows': 'win_amd64',
-                      'Linux': 'linux_x86_64', "Macos": 'macosx-10.6-intel'}
-        self.run('python setup.py bdist_wheel --plat-name={} --dist-dir {}'.format(
-            plat_names[str(self.settings.os)],
+        self.run('python setup.py bdist_wheel --dist-dir {}'.format(
             os.path.join(self.build_folder, "dist")), cwd=os.path.join(self.package_folder, "_package"))
         self.run(
             'devpi upload --from-dir {}'.format(os.path.join(self.build_folder, "dist")), cwd=".")


### PR DESCRIPTION
Requires setup.py to use distclass=BinaryDistribution where BinaryDistribution is an override of setuptool.dist.Distribution where has_ext_modules method returns true.