### PR TITLE
Limit Numpy to < 2.0

### DIFF
--- a/.github/workflows/xmsconan-ci.yaml
+++ b/.github/workflows/xmsconan-ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-18.04]
+        platform: [ubuntu-latest]
         python-version: ["3.10"]
 
     steps:

--- a/xmsconan/xms_conan_file.py
+++ b/xmsconan/xms_conan_file.py
@@ -154,7 +154,7 @@ class XmsConanFile(ConanFile):
         with tools.pythonpath(self):
 
             # Install required packages for python testing.
-            packages_to_install = ['numpy', 'wheel']
+            packages_to_install = ['"numpy<2.0"', 'wheel']
             if not self.settings.os == "Macos":
                 self.run(f'pip install --user {" ".join(packages_to_install)}')
             else:


### PR DESCRIPTION
### Description
Limit the version of numpy to less than 2.0

### Changes Made to Code:
 - Limit the version of numpy to less than 2.0
 - Change to use latest ubuntu for flaking

### Quality Checks
 - [x ] New code is 100% tested
 - [x ] Code has been formated
 - [x ] Code has been linted
 - [x ] Docstrings for new methods have been added
