### PR TITLE
Release 2.3.4: Use conan-gcc13-x11-gdal image conditionally in GitLab CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xmsconan"
-version = "2.3.3"
+version = "2.3.4"
 description = "Methods and Modules used to aid in xmsconan projects"
 authors = [
     {name = "Gage Larsen"}

--- a/xmsconan/__init__.py
+++ b/xmsconan/__init__.py
@@ -1,4 +1,4 @@
 """
 Methods and Modules used to aid in xmsconan projects.
 """
-__version__ = '2.3.3'
+__version__ = '2.3.4'

--- a/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
+++ b/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
@@ -94,7 +94,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.3.3 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install xmsconan>=2.3.4 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: |
@@ -233,7 +233,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan devpi-client wheel
-          pip install xmsconan>=2.3.3 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install xmsconan>=2.3.4 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: |
@@ -382,7 +382,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.3.3 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install xmsconan>=2.3.4 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2

--- a/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
+++ b/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
@@ -17,7 +17,11 @@ variables:
 <% endif %>
 Conan Build:
   stage: Test
+<% if ci_xvfb %>
+  image: docker.aquaveo.com/aquaveo/conan-docker/conan-gcc13-x11-gdal
+<% else %>
   image: docker.aquaveo.com/aquaveo/conan-docker/conan-gcc13-py3.13
+<% endif %>
 <% if ci_windows %>
   services:
     - name: docker:dind
@@ -36,9 +40,7 @@ Conan Build:
 <% endif %>
       - wheelhouse/
   script:
-<% if ci_xvfb %>
-    - apt-get update && apt-get install -y xvfb
-<% elif ci_windows %>
+<% if ci_windows %>
     - apt-get update && apt-get install -y ca-certificates curl
     - curl -fsSL https://get.docker.com | sh
     - docker --version
@@ -46,7 +48,7 @@ Conan Build:
     - gcc --version
     - cmake --version
     - python --version
-    - pip install xmsconan>=2.3.3 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install xmsconan>=2.3.4 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - export PACKAGE_VERSION=${CI_COMMIT_TAG:-0.0.0}
     - xmsconan_gen --version ${PACKAGE_VERSION} build.toml
 <% if ci_xvfb %>
@@ -75,7 +77,7 @@ Conan Build:
     - echo ${PACKAGE_VERSION}
     - python --version
     - pip install conan toml packaging devpi-client
-    - python -m pip install xmsconan>=2.3.3 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - python -m pip install xmsconan>=2.3.4 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - conan remote add --index 0 aquaveo https://conan2.aquaveo.com/artifactory/api/conan/aquaveo-stable
     - conan profile detect
     - xmsconan_gen --version ${PACKAGE_VERSION} build.toml
@@ -99,16 +101,14 @@ Lint:
 
 Repair Wheel:
   stage: Package
+<% if ci_xvfb %>
+  image: docker.aquaveo.com/aquaveo/conan-docker/conan-gcc13-x11-gdal
+<% else %>
   image: quay.io/pypa/manylinux_2_28_x86_64
+<% endif %>
   dependencies:
     - Conan Build
   script:
-    - yum install -y
-        mesa-libGL mesa-libEGL mesa-libGLES
-        libX11 libXcursor libXrandr libXinerama
-        libXi libXxf86vm libXext libXrender
-        libXfixes libXft libXmu libXt
-        libSM libICE
     - /opt/python/cp313-cp313/bin/pip install auditwheel patchelf
     - LD_LIBRARY_PATH=wheelhouse/libs /opt/python/cp313-cp313/bin/auditwheel repair wheelhouse/*.whl -w wheelhouse_repaired
     - rm -rf wheelhouse
@@ -177,10 +177,14 @@ Repair Wheel:
 <% if ci_coverage %>
 Coverage:
   stage: Coverage
+<% if ci_xvfb %>
+  image: docker.aquaveo.com/aquaveo/conan-docker/conan-gcc13-x11-gdal
+<% else %>
   image: docker.aquaveo.com/aquaveo/conan-docker/conan-gcc13-py3.13
+<% endif %>
   script:
     - pip install lxml
-    - pip install xmsconan>=2.3.3 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install xmsconan>=2.3.4 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_gen --version 0.0.0 build.toml
     - conan install -pr conan_profiles/linux_testing_debug_coverage.txt . -c tools.cmake.cmake_layout:build_folder_vars="['self.name', 'const.coverage']" --build=missing
     - cmake --preset coverage


### PR DESCRIPTION
- Gate the heavier conan-gcc13-x11-gdal Docker image on ci_xvfb flag, keeping most libraries on the lightweight conan-gcc13-py3.13 image
- Remove redundant apt-get install xvfb (pre-installed in x11-gdal image)
- Remove yum install of X11/Mesa libs from Repair Wheel stage when using x11-gdal image; non-xvfb libraries use bare manylinux_2_28 without them
- Bump version to 2.3.4