### PR TITLE
Fix CI publish: install xmsconan before tag check

### DIFF
--- a/.github/workflows/xmsconan-ci.yaml
+++ b/.github/workflows/xmsconan-ci.yaml
@@ -92,7 +92,8 @@ jobs:
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install wheel setuptools devpi
+          pip install wheel setuptools setuptools-scm devpi
+          pip install .
       # Get Tag Name
       - name: Get Tag
         id: gitTag


### PR DESCRIPTION
## Summary
- The publish job checked `__version__` but never installed xmsconan, so `importlib.metadata` fell back to `0.0.0` and the tag check failed.
- Added `pip install .` after setuptools-scm so the version is derived from the git tag.

## Test plan
- [ ] Merge and tag `2.6.0` — verify the publish job passes the tag check and uploads the wheel.