### PR TITLE
Add test artifact collection from Conan builds to CI

### DIFF
--- a/tests/test_ci_file_generator.py
+++ b/tests/test_ci_file_generator.py
@@ -251,6 +251,82 @@ def test_github_ci_version_bump(ci_toml, tmp_path):
     assert f"xmsconan>={__version__}" in content
 
 
+def test_github_ci_includes_artifacts_dir_flag(ci_toml, tmp_path):
+    """Rendered GitHub CI build commands include --artifacts-dir test_artifacts."""
+    output_dir = tmp_path / "output"
+    generate_ci(str(ci_toml), "1.0.0", str(output_dir))
+    ci_file = output_dir / ".github" / "workflows" / "XmsCore-CI.yaml"
+    content = ci_file.read_text(encoding="utf-8")
+    assert "--artifacts-dir test_artifacts" in content
+
+
+def test_github_ci_includes_test_artifact_upload(ci_toml, tmp_path):
+    """Rendered GitHub CI has upload-artifact steps for test artifacts."""
+    output_dir = tmp_path / "output"
+    generate_ci(str(ci_toml), "1.0.0", str(output_dir))
+    ci_file = output_dir / ".github" / "workflows" / "XmsCore-CI.yaml"
+    content = ci_file.read_text(encoding="utf-8")
+    assert "test-artifacts-" in content
+    assert "test_artifacts/" in content
+
+
+def test_github_ci_test_artifact_upload_uses_always(ci_toml, tmp_path):
+    """Verify test artifact upload step uses if: always()."""
+    output_dir = tmp_path / "output"
+    generate_ci(str(ci_toml), "1.0.0", str(output_dir))
+    ci_file = output_dir / ".github" / "workflows" / "XmsCore-CI.yaml"
+    content = ci_file.read_text(encoding="utf-8")
+    # Find lines with "Upload test artifacts" and check the surrounding context
+    lines = content.splitlines()
+    for i, line in enumerate(lines):
+        if "Upload test artifacts" in line:
+            # Look for 'if: always()' within the next few lines
+            block = "\n".join(lines[i:i + 8])
+            assert "always()" in block
+
+
+def test_gitlab_ci_includes_artifacts_dir_flag(tmp_path):
+    """Rendered GitLab CI build commands include --artifacts-dir test_artifacts."""
+    toml_file = tmp_path / "build.toml"
+    toml_file.write_text(
+        'library_name = "xmscore"\ndescription = "desc"\nci_type = "gitlab"\n',
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    generate_ci(str(toml_file), "1.0.0", str(output_dir))
+    ci_file = output_dir / ".gitlab-ci.yml"
+    content = ci_file.read_text(encoding="utf-8")
+    assert "--artifacts-dir test_artifacts" in content
+
+
+def test_gitlab_ci_includes_test_artifacts_path(tmp_path):
+    """Rendered GitLab CI artifacts paths include test_artifacts/."""
+    toml_file = tmp_path / "build.toml"
+    toml_file.write_text(
+        'library_name = "xmscore"\ndescription = "desc"\nci_type = "gitlab"\n',
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    generate_ci(str(toml_file), "1.0.0", str(output_dir))
+    ci_file = output_dir / ".gitlab-ci.yml"
+    content = ci_file.read_text(encoding="utf-8")
+    assert "test_artifacts/" in content
+
+
+def test_gitlab_ci_uses_when_always(tmp_path):
+    """Rendered GitLab CI Conan Build job uses when: always for artifacts."""
+    toml_file = tmp_path / "build.toml"
+    toml_file.write_text(
+        'library_name = "xmscore"\ndescription = "desc"\nci_type = "gitlab"\n',
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    generate_ci(str(toml_file), "1.0.0", str(output_dir))
+    ci_file = output_dir / ".gitlab-ci.yml"
+    content = ci_file.read_text(encoding="utf-8")
+    assert "when: always" in content
+
+
 def test_python_namespaced_dir_defaults_to_suffix(tmp_path):
     """python_namespaced_dir defaults to library_name[3:]."""
     toml_file = tmp_path / "build.toml"

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -302,3 +302,94 @@ def test_upload_handles_called_process_error(mock_run):
     p = XmsConanPackager("xmscore")
     # Should not raise — CalledProcessError is caught internally
     p.upload("7.0.0")
+
+
+# --- artifacts_dir ---
+
+
+def test_init_accepts_artifacts_dir(tmp_path):
+    """artifacts_dir is stored as an absolute path."""
+    p = XmsConanPackager("xmscore", artifacts_dir=str(tmp_path / "arts"))
+    assert p._artifacts_dir == str(tmp_path / "arts")
+
+
+def test_init_artifacts_dir_defaults_to_none():
+    """artifacts_dir is None when not provided."""
+    p = XmsConanPackager("xmscore")
+    assert p._artifacts_dir is None
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_generate_configurations_injects_artifacts_dir(tmp_path):
+    """Every configuration gets XMS_TEST_ARTIFACTS_DIR when artifacts_dir set."""
+    p = XmsConanPackager("xmscore", artifacts_dir=str(tmp_path))
+    p.generate_configurations(system_platform="linux")
+
+    for cfg in p.configurations:
+        assert cfg["buildenv"]["XMS_TEST_ARTIFACTS_DIR"] == str(tmp_path)
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_generate_configurations_no_artifacts_dir():
+    """XMS_TEST_ARTIFACTS_DIR absent when artifacts_dir not set."""
+    p = XmsConanPackager("xmscore")
+    p.generate_configurations(system_platform="linux")
+
+    for cfg in p.configurations:
+        assert "XMS_TEST_ARTIFACTS_DIR" not in cfg["buildenv"]
+
+
+# --- _config_label ---
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_config_label_testing():
+    """Testing config produces 'Release-testing' label."""
+    p = XmsConanPackager("xmscore")
+    combo = {"build_type": "Release", "options": {"testing": True, "pybind": False, "wchar_t": "builtin"}}
+    assert p._config_label(combo) == "Release-testing"
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_config_label_pybind():
+    """Pybind config produces 'Release-pybind' label."""
+    p = XmsConanPackager("xmscore")
+    combo = {"build_type": "Release", "options": {"testing": False, "pybind": True, "wchar_t": "builtin"}}
+    assert p._config_label(combo) == "Release-pybind"
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_config_label_wchar_typedef():
+    """wchar_t=typedef suffix appears in label."""
+    p = XmsConanPackager("xmscore")
+    combo = {"build_type": "Release", "options": {"testing": True, "pybind": False, "wchar_t": "typedef"}}
+    assert p._config_label(combo) == "Release-testing-wchar_typedef"
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_config_label_plain():
+    """Plain config (no testing, no pybind) is just build_type."""
+    p = XmsConanPackager("xmscore")
+    combo = {"build_type": "Debug", "options": {"testing": False, "pybind": False, "wchar_t": "builtin"}}
+    assert p._config_label(combo) == "Debug"
+
+
+# --- run with artifacts ---
+
+
+@patch.dict("os.environ", {}, clear=True)
+@patch("xmsconan.package_tools.packager.subprocess.run")
+def test_run_injects_label_into_profile(mock_run, tmp_path):
+    """Profile written during run() contains XMS_TEST_ARTIFACTS_LABEL."""
+    p = XmsConanPackager("xmscore", artifacts_dir=str(tmp_path))
+    p.generate_configurations(system_platform="linux")
+    p.filter_configurations({"build_type": "Release", "options": {"testing": True}})
+
+    p.run()
+
+    # Read the profile that was written
+    profile_path = p._temp_dir_path + "/temp_profile"
+    with open(profile_path, "r") as f:
+        content = f.read()
+    assert "XMS_TEST_ARTIFACTS_LABEL=Release-testing" in content
+    assert f"XMS_TEST_ARTIFACTS_DIR={tmp_path}" in content

--- a/tests/test_xms_conan2_file.py
+++ b/tests/test_xms_conan2_file.py
@@ -122,6 +122,124 @@ class TestBuildWheelPlatformOverride:
         assert "_PYTHON_HOST_PLATFORM" not in os.environ
 
 
+class TestSaveTestArtifacts:
+    """Verify _save_test_artifacts copies the right files."""
+
+    def _make_obj(self, tmp_path, testing=False, pybind=False, artifacts_dir=None, label="test-label"):
+        """Create an XmsConan2File with real temp directories."""
+        obj = object.__new__(XmsConan2File)
+        obj.settings = MagicMock()
+        obj.build_folder = str(tmp_path / "build")
+        obj.source_folder = str(tmp_path / "source")
+        obj.output = MagicMock()
+
+        os.makedirs(obj.build_folder, exist_ok=True)
+        os.makedirs(obj.source_folder, exist_ok=True)
+
+        # Mock options
+        obj.options = MagicMock()
+        obj.options.testing = testing
+        obj.options.pybind = pybind
+
+        # Mock buildenv
+        env = {}
+        if artifacts_dir:
+            env["XMS_TEST_ARTIFACTS_DIR"] = str(artifacts_dir)
+            env["XMS_TEST_ARTIFACTS_LABEL"] = label
+        obj.buildenv = MagicMock()
+        obj.buildenv.vars.return_value = env
+
+        return obj
+
+    def test_noop_when_not_configured(self, tmp_path):
+        """Returns early when XMS_TEST_ARTIFACTS_DIR is not set."""
+        obj = self._make_obj(tmp_path, testing=True)
+        obj._save_test_artifacts()
+        # No makedirs call → nothing created
+        assert not (tmp_path / "artifacts").exists()
+
+    def test_copies_lasttest_log(self, tmp_path):
+        """LastTest.log is copied for testing builds."""
+        dest = tmp_path / "artifacts"
+        obj = self._make_obj(tmp_path, testing=True, artifacts_dir=dest, label="Release-testing")
+
+        # Create LastTest.log in build folder
+        log_dir = os.path.join(obj.build_folder, "Testing", "Temporary")
+        os.makedirs(log_dir)
+        log_path = os.path.join(log_dir, "LastTest.log")
+        with open(log_path, "w") as f:
+            f.write("test output")
+
+        obj._save_test_artifacts()
+
+        copied = dest / "Release-testing" / "LastTest.log"
+        assert copied.exists()
+        assert copied.read_text() == "test output"
+
+    def test_copies_test_files_for_testing(self, tmp_path):
+        """test_files/ from source_folder is copied for testing builds."""
+        dest = tmp_path / "artifacts"
+        obj = self._make_obj(tmp_path, testing=True, artifacts_dir=dest, label="Debug-testing")
+
+        # Create test_files in source folder
+        tf_dir = os.path.join(obj.source_folder, "test_files")
+        os.makedirs(tf_dir)
+        with open(os.path.join(tf_dir, "output.png"), "w") as f:
+            f.write("image data")
+
+        obj._save_test_artifacts()
+
+        copied = dest / "Debug-testing" / "test_files" / "output.png"
+        assert copied.exists()
+        assert copied.read_text() == "image data"
+
+    def test_skips_test_files_for_pybind(self, tmp_path):
+        """test_files/ is NOT copied for pybind builds."""
+        dest = tmp_path / "artifacts"
+        obj = self._make_obj(tmp_path, pybind=True, artifacts_dir=dest, label="Release-pybind")
+
+        # Create test_files in source folder (should be ignored)
+        tf_dir = os.path.join(obj.source_folder, "test_files")
+        os.makedirs(tf_dir)
+        with open(os.path.join(tf_dir, "output.png"), "w") as f:
+            f.write("image data")
+
+        obj._save_test_artifacts()
+
+        assert not (dest / "Release-pybind" / "test_files").exists()
+
+    def test_copies_python_tests_for_pybind(self, tmp_path):
+        """build_folder/tests/ is copied for pybind builds."""
+        dest = tmp_path / "artifacts"
+        obj = self._make_obj(tmp_path, pybind=True, artifacts_dir=dest, label="Release-pybind")
+
+        # Create tests dir in build folder
+        tests_dir = os.path.join(obj.build_folder, "tests")
+        os.makedirs(tests_dir)
+        with open(os.path.join(tests_dir, "test_pyt.py"), "w") as f:
+            f.write("import unittest")
+
+        obj._save_test_artifacts()
+
+        copied = dest / "Release-pybind" / "python_tests" / "test_pyt.py"
+        assert copied.exists()
+
+    def test_skips_python_tests_for_testing(self, tmp_path):
+        """build_folder/tests/ is NOT copied for testing (C++) builds."""
+        dest = tmp_path / "artifacts"
+        obj = self._make_obj(tmp_path, testing=True, artifacts_dir=dest, label="Release-testing")
+
+        # Create tests dir in build folder (should be ignored for C++ testing)
+        tests_dir = os.path.join(obj.build_folder, "tests")
+        os.makedirs(tests_dir)
+        with open(os.path.join(tests_dir, "test_pyt.py"), "w") as f:
+            f.write("import unittest")
+
+        obj._save_test_artifacts()
+
+        assert not (dest / "Release-testing" / "python_tests").exists()
+
+
 class TestGetPythonCmakeHints:
     """Verify _get_python_cmake_hints returns correct FindPython3 hints."""
 

--- a/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
+++ b/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
@@ -138,8 +138,15 @@ jobs:
         run: xmsconan_gen --version ${{ env.XMS_VERSION }} build.toml
       # Build the Conan Package
       - name: Build the Conan Packages
-        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse"
+        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse --artifacts-dir test_artifacts"
         shell: bash
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ env.MATRIX_NAME }}
+          path: test_artifacts/
+          if-no-files-found: ignore
+        if: always()
       # Repair wheel (Release only)
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform macos
@@ -269,8 +276,15 @@ jobs:
         run: xmsconan_gen --version ${{ env.XMS_VERSION }} build.toml
       # Build the Conan Package
       - name: Build the Conan Packages
-        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse"
+        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse --artifacts-dir test_artifacts"
         shell: bash
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ env.MATRIX_NAME }}
+          path: test_artifacts/
+          if-no-files-found: ignore
+        if: always()
       # Repair wheel (Release only)
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform linux
@@ -401,8 +415,15 @@ jobs:
         run: xmsconan_gen --version ${{ env.XMS_VERSION }} build.toml
       # Build the Conan Package
       - name: Build the Conan Packages
-        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse"
+        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse --artifacts-dir test_artifacts"
         shell: bash
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ env.MATRIX_NAME }}
+          path: test_artifacts/
+          if-no-files-found: ignore
+        if: always()
       # Repair wheel (Release only)
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform linux
@@ -542,8 +563,15 @@ jobs:
         run: xmsconan_gen --version ${{ env.XMS_VERSION }} build.toml
       # Build the Conan Package
       - name: Build the Conan Packages
-        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse"
+        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse --artifacts-dir test_artifacts"
         shell: cmd
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ env.MATRIX_NAME }}
+          path: test_artifacts/
+          if-no-files-found: ignore
+        if: always()
       # Repair wheel (Release only)
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform windows

--- a/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
+++ b/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
@@ -35,11 +35,13 @@ Conan Build:
 <% endif %>
   artifacts:
     expire_in: '1d'
+    when: always
     paths:
 <% if ci_deploy %>
       - .export
 <% endif %>
       - wheelhouse/
+      - test_artifacts/
   script:
     - gcc --version
     - cmake --version
@@ -49,9 +51,9 @@ Conan Build:
     - export PACKAGE_VERSION=${CI_COMMIT_TAG:-0.0.0}
     - xmsconan_gen --version ${PACKAGE_VERSION} build.toml
 <% if ci_xvfb %>
-    - xvfb-run -a -s "-screen 0 1280x1024x24" python build.py --version ${PACKAGE_VERSION} --wheel-dir wheelhouse
+    - xvfb-run -a -s "-screen 0 1280x1024x24" python build.py --version ${PACKAGE_VERSION} --wheel-dir wheelhouse --artifacts-dir test_artifacts
 <% else %>
-    - python build.py --version ${PACKAGE_VERSION} --wheel-dir wheelhouse
+    - python build.py --version ${PACKAGE_VERSION} --wheel-dir wheelhouse --artifacts-dir test_artifacts
 <% endif %>
 <% if ci_deploy %>
     - xmsconan_conan_deploy << library_name >> ${PACKAGE_VERSION} --save .export/<< library_name >>-linux-${PACKAGE_VERSION}.tar.gz
@@ -65,8 +67,10 @@ Conan Build:
     AQUAPI_URL: "https://aquapi.aquaveo.com/aquaveo/dev"
   artifacts:
     expire_in: '1d'
+    when: always
     paths:
       - .export
+      - test_artifacts/
   script:
     - export PACKAGE_VERSION=${CI_COMMIT_TAG:-0.0.0}
     - echo ${PACKAGE_VERSION}
@@ -75,7 +79,7 @@ Conan Build:
     - python -m pip install xmsconan>=<< xmsconan_version >> -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_conan_setup
     - xmsconan_gen --version ${PACKAGE_VERSION} build.toml
-    - python build.py --version ${PACKAGE_VERSION}
+    - python build.py --version ${PACKAGE_VERSION} --artifacts-dir test_artifacts
     - xmsconan_conan_deploy << library_name >> ${PACKAGE_VERSION} --save .export/<< library_name >>-windows-${PACKAGE_VERSION}.tar.gz
   tags:
     - WinVM

--- a/xmsconan/generator_tools/templates/build.py.jinja
+++ b/xmsconan/generator_tools/templates/build.py.jinja
@@ -20,13 +20,15 @@ parser.add_argument("--build-missing", help="Build missing dependencies from sou
 parser.add_argument("--python-only", help="Only build the Python (pybind) configuration", action="store_true")
 parser.add_argument("--wheel-dir", help="Extract pre-built wheel from pybind package to this directory")
 parser.add_argument("--repair", help="Repair Linux wheel for manylinux using Docker", action="store_true")
+parser.add_argument("--artifacts-dir", help="Save test artifacts to this directory")
 
 if __name__ == "__main__":
     args = parser.parse_args()
     builder = packager.XmsConanPackager(
         conanfile.LIBRARY_NAME,
         conanfile.__file__,
-        build_missing=args.build_missing
+        build_missing=args.build_missing,
+        artifacts_dir=args.artifacts_dir,
     )
     builder.generate_configurations()
     if args.filter:

--- a/xmsconan/package_tools/packager.py
+++ b/xmsconan/package_tools/packager.py
@@ -57,18 +57,20 @@ configurations = {
 class XmsConanPackager(object):
     """The packager class."""
 
-    def __init__(self, library_name, conanfile_path='.', build_missing=False):
+    def __init__(self, library_name, conanfile_path='.', build_missing=False, artifacts_dir=None):
         """Initialize the packager.
 
         Args:
             library_name: Name of the library to build.
             conanfile_path: Path to the conanfile.
             build_missing: If True, build missing dependencies from source.
+            artifacts_dir: If set, test artifacts are saved here during builds.
         """
         self._library_name = library_name
         self._conanfile_path = conanfile_path
         self._configurations = None
         self._build_missing = build_missing
+        self._artifacts_dir = os.path.abspath(artifacts_dir) if artifacts_dir else None
         self.printer = Printer()
         self._temp_dir = tempfile.TemporaryDirectory()
         self._temp_dir_path = self._temp_dir.name
@@ -132,6 +134,9 @@ class XmsConanPackager(object):
                 'AQUAPI_PASSWORD': aquapi_password,
                 'AQUAPI_URL': aquapi_url,
             }
+            if self._artifacts_dir:
+                combination['buildenv']['XMS_TEST_ARTIFACTS_DIR'] = self._artifacts_dir
+
             # Set macOS deployment target for consistent wheel builds
             if combination.get('os') == 'Macos':
                 combination['buildenv']['MACOSX_DEPLOYMENT_TARGET'] = '15.0'
@@ -192,6 +197,18 @@ class XmsConanPackager(object):
                 filtered_configurations.append(configuration)
         self._configurations = filtered_configurations
 
+    def _config_label(self, combination):
+        """Return a human-readable label for a build configuration."""
+        parts = [combination.get('build_type', 'unknown')]
+        opts = combination.get('options', {})
+        if opts.get('testing'):
+            parts.append('testing')
+        elif opts.get('pybind'):
+            parts.append('pybind')
+        if opts.get('wchar_t') == 'typedef':
+            parts.append('wchar_typedef')
+        return '-'.join(parts)
+
     def run(self):
         """Run the build process."""
         self.printer.print_ascci_art()
@@ -200,7 +217,11 @@ class XmsConanPackager(object):
         for i, combination in enumerate(self.configurations):
             self.printer.print_message('*-' * 40 + '\n')
             self.printer.print_message(f'Building configuration {i + 1} of {len(self.configurations)}')
-            profile_path = self.create_build_profile(combination)
+            build_combination = combination
+            if self._artifacts_dir:
+                build_combination = copy.deepcopy(combination)
+                build_combination['buildenv']['XMS_TEST_ARTIFACTS_LABEL'] = self._config_label(combination)
+            profile_path = self.create_build_profile(build_combination)
             self.printer.print_profile(profile_path)
             cmd = ['conan', 'create', self._conanfile_path, '--profile', profile_path]
             if self._build_missing:

--- a/xmsconan/xms_conan2_file.py
+++ b/xmsconan/xms_conan2_file.py
@@ -168,12 +168,18 @@ class XmsConan2File(ConanFile):
 
         # Run the tests if it is testing configuration.
         if self.options.testing:
-            self.run_cxx_tests(cmake)
+            try:
+                self.run_cxx_tests(cmake)
+            finally:
+                self._save_test_artifacts()
 
         # If this build is python, build the wheel then run tests.
         elif self.options.pybind:
             self._build_wheel()
-            self.run_python_tests()
+            try:
+                self.run_python_tests()
+            finally:
+                self._save_test_artifacts()
 
     def package(self):
         """The package method of the conan class."""
@@ -213,6 +219,52 @@ class XmsConan2File(ConanFile):
                     for line in f.readlines():
                         no_newline = line.strip('\n')
                         self.output.info(no_newline)
+
+    def _save_test_artifacts(self):
+        """Copy test artifacts to an external directory if configured.
+
+        Reads XMS_TEST_ARTIFACTS_DIR and XMS_TEST_ARTIFACTS_LABEL from the
+        build environment.  For testing builds, copies LastTest.log and the
+        test_files/ directory.  For pybind builds, copies the Python test
+        output directory.
+        """
+        env_vars = self.buildenv.vars(self)
+        artifacts_dir = env_vars.get("XMS_TEST_ARTIFACTS_DIR")
+        if not artifacts_dir:
+            return
+
+        label = env_vars.get("XMS_TEST_ARTIFACTS_LABEL", "unknown")
+        dest = os.path.join(artifacts_dir, label)
+        os.makedirs(dest, exist_ok=True)
+        self.output.info(f"Saving test artifacts to {dest}")
+
+        # CTest log
+        last_test_log = os.path.join(
+            self.build_folder, "Testing", "Temporary", "LastTest.log"
+        )
+        if os.path.isfile(last_test_log):
+            shutil.copy2(last_test_log, os.path.join(dest, "LastTest.log"))
+            self.output.info("  Copied LastTest.log")
+
+        # test_files/ — testing builds only (lives in source_folder per CMakeLists.txt)
+        if self.options.testing:
+            test_files_src = os.path.join(self.source_folder, "test_files")
+            if os.path.isdir(test_files_src):
+                dest_tf = os.path.join(dest, "test_files")
+                if os.path.exists(dest_tf):
+                    shutil.rmtree(dest_tf)
+                shutil.copytree(test_files_src, dest_tf)
+                self.output.info("  Copied test_files/")
+
+        # Python test output — pybind builds only
+        if self.options.pybind:
+            tests_src = os.path.join(self.build_folder, "tests")
+            if os.path.isdir(tests_src):
+                dest_tests = os.path.join(dest, "python_tests")
+                if os.path.exists(dest_tests):
+                    shutil.rmtree(dest_tests)
+                shutil.copytree(tests_src, dest_tests)
+                self.output.info("  Copied python test output")
 
     def _build_wheel(self):
         """Build a wheel from _package/ into build_folder/dist/."""


### PR DESCRIPTION
Conan builds run inside the cache at unpredictable hash-based paths, so test logs and output files were lost after CI jobs finished. This adds --artifacts-dir to build.py so the packager can tell each Conan build where to save diagnostics via buildenv variables.

- XmsConan2File._save_test_artifacts() copies LastTest.log and test_files/ for testing builds, python_tests/ for pybind builds
- Wrapped test execution in build() with finally blocks so artifacts are captured even on test failure
- XmsConanPackager passes XMS_TEST_ARTIFACTS_DIR and per-config labels (e.g. Release-testing, Release-pybind) through the Conan profile
- GitHub CI template: upload-artifact step with if: always()
- GitLab CI template: when: always on artifacts, test_artifacts/ path