### PR TITLE
Copy _package/ for pybind artifacts, add pytest/flake8 config generation

### DIFF
--- a/tests/test_build_file_generator.py
+++ b/tests/test_build_file_generator.py
@@ -1,4 +1,6 @@
 """Tests for generator_tools.build_file_generator."""
+from pathlib import Path
+
 import pytest
 
 from xmsconan.generator_tools.build_file_generator import (
@@ -176,3 +178,57 @@ def test_copy_xms_conan2_file_copies(tmp_path):
     """Normal mode copies xms_conan2_file.py to output dir."""
     copy_xms_conan2_file(str(tmp_path), dry_run=False)
     assert (tmp_path / "xms_conan2_file.py").exists()
+
+
+# --- Template generation tests ---
+
+REAL_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "xmsconan" / "generator_tools" / "templates"
+
+
+def _copy_template(name, dest_dir):
+    """Copy a single template from the real template dir into dest_dir."""
+    src = REAL_TEMPLATE_DIR / name
+    dst = dest_dir / name
+    dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+def test_generates_pytest_ini(build_toml, tmp_path):
+    """pytest.ini is generated with *_pyt.py discovery pattern."""
+    tpl_dir = tmp_path / "tpl"
+    tpl_dir.mkdir()
+    _copy_template("pytest.ini.jinja", tpl_dir)
+
+    output_dir = tmp_path / "output"
+    render_template_with_toml(
+        toml_file_path=str(build_toml),
+        version="1.0.0",
+        template_dir=str(tpl_dir),
+        output_dir=str(output_dir),
+    )
+
+    pytest_ini = output_dir / "pytest.ini"
+    assert pytest_ini.exists()
+    content = pytest_ini.read_text(encoding="utf-8")
+    assert "*_pyt.py" in content
+    assert "testpaths = _package/tests" in content
+
+
+def test_generates_flake8(build_toml, tmp_path):
+    """.flake8 is generated with library_name substituted."""
+    tpl_dir = tmp_path / "tpl"
+    tpl_dir.mkdir()
+    _copy_template(".flake8.jinja", tpl_dir)
+
+    output_dir = tmp_path / "output"
+    render_template_with_toml(
+        toml_file_path=str(build_toml),
+        version="1.0.0",
+        template_dir=str(tpl_dir),
+        output_dir=str(output_dir),
+    )
+
+    flake8 = output_dir / ".flake8"
+    assert flake8.exists()
+    content = flake8.read_text(encoding="utf-8")
+    assert "application-import-names = xmscore" in content
+    assert "application-package-names = xms" in content

--- a/tests/test_xms_conan2_file.py
+++ b/tests/test_xms_conan2_file.py
@@ -208,36 +208,37 @@ class TestSaveTestArtifacts:
 
         assert not (dest / "Release-pybind" / "test_files").exists()
 
-    def test_copies_python_tests_for_pybind(self, tmp_path):
-        """build_folder/tests/ is copied for pybind builds."""
+    def test_copies_package_for_pybind(self, tmp_path):
+        """source_folder/_package/ is copied for pybind builds."""
         dest = tmp_path / "artifacts"
         obj = self._make_obj(tmp_path, pybind=True, artifacts_dir=dest, label="Release-pybind")
 
-        # Create tests dir in build folder
-        tests_dir = os.path.join(obj.build_folder, "tests")
-        os.makedirs(tests_dir)
-        with open(os.path.join(tests_dir, "test_pyt.py"), "w") as f:
-            f.write("import unittest")
+        # Create _package dir in source folder
+        pkg_dir = os.path.join(obj.source_folder, "_package", "tests", "files")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "output.2dm"), "w") as f:
+            f.write("mesh data")
 
         obj._save_test_artifacts()
 
-        copied = dest / "Release-pybind" / "python_tests" / "test_pyt.py"
+        copied = dest / "Release-pybind" / "_package" / "tests" / "files" / "output.2dm"
         assert copied.exists()
+        assert copied.read_text() == "mesh data"
 
-    def test_skips_python_tests_for_testing(self, tmp_path):
-        """build_folder/tests/ is NOT copied for testing (C++) builds."""
+    def test_skips_package_for_testing(self, tmp_path):
+        """source_folder/_package/ is NOT copied for testing (C++) builds."""
         dest = tmp_path / "artifacts"
         obj = self._make_obj(tmp_path, testing=True, artifacts_dir=dest, label="Release-testing")
 
-        # Create tests dir in build folder (should be ignored for C++ testing)
-        tests_dir = os.path.join(obj.build_folder, "tests")
-        os.makedirs(tests_dir)
-        with open(os.path.join(tests_dir, "test_pyt.py"), "w") as f:
-            f.write("import unittest")
+        # Create _package dir in source folder (should be ignored for C++ testing)
+        pkg_dir = os.path.join(obj.source_folder, "_package")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "setup.py"), "w") as f:
+            f.write("from setuptools import setup")
 
         obj._save_test_artifacts()
 
-        assert not (dest / "Release-testing" / "python_tests").exists()
+        assert not (dest / "Release-testing" / "_package").exists()
 
 
 class TestGetPythonCmakeHints:

--- a/xmsconan/generator_tools/templates/.flake8.jinja
+++ b/xmsconan/generator_tools/templates/.flake8.jinja
@@ -1,0 +1,22 @@
+[flake8]
+exclude =
+    .venv,
+    .tox,
+    .git,
+    __pycache__,
+    _package/tests/files/*,
+    build,
+    dist,
+    *.pyc,
+    *.egg-info,
+    .cache,
+    .eggs
+ignore = D200, D212
+max-line-length = 125
+docstring-convention = google
+isolated = true
+import-order-style = appnexus
+application-import-names = {{ library_name }}
+application-package-names = xms
+count = true
+statistics = true

--- a/xmsconan/generator_tools/templates/pytest.ini.jinja
+++ b/xmsconan/generator_tools/templates/pytest.ini.jinja
@@ -1,0 +1,3 @@
+[pytest]
+python_files = test_*.py *_test.py *_pyt.py
+testpaths = _package/tests

--- a/xmsconan/xms_conan2_file.py
+++ b/xmsconan/xms_conan2_file.py
@@ -225,8 +225,8 @@ class XmsConan2File(ConanFile):
 
         Reads XMS_TEST_ARTIFACTS_DIR and XMS_TEST_ARTIFACTS_LABEL from the
         build environment.  For testing builds, copies LastTest.log and the
-        test_files/ directory.  For pybind builds, copies the Python test
-        output directory.
+        test_files/ directory.  For pybind builds, copies the _package/
+        directory (module, tests, and baseline files).
         """
         env_vars = self.buildenv.vars(self)
         artifacts_dir = env_vars.get("XMS_TEST_ARTIFACTS_DIR")
@@ -256,15 +256,15 @@ class XmsConan2File(ConanFile):
                 shutil.copytree(test_files_src, dest_tf)
                 self.output.info("  Copied test_files/")
 
-        # Python test output — pybind builds only
+        # _package/ — pybind builds only (contains module, tests, and baselines)
         if self.options.pybind:
-            tests_src = os.path.join(self.build_folder, "tests")
-            if os.path.isdir(tests_src):
-                dest_tests = os.path.join(dest, "python_tests")
-                if os.path.exists(dest_tests):
-                    shutil.rmtree(dest_tests)
-                shutil.copytree(tests_src, dest_tests)
-                self.output.info("  Copied python test output")
+            package_src = os.path.join(self.source_folder, "_package")
+            if os.path.isdir(package_src):
+                dest_pkg = os.path.join(dest, "_package")
+                if os.path.exists(dest_pkg):
+                    shutil.rmtree(dest_pkg)
+                shutil.copytree(package_src, dest_pkg)
+                self.output.info("  Copied _package/")
 
     def _build_wheel(self):
         """Build a wheel from _package/ into build_folder/dist/."""
@@ -315,7 +315,7 @@ class XmsConan2File(ConanFile):
             self.run(f'"{sys.executable}" -m venv {build_venv_dir}')
 
         # Install general dependencies
-        general_dependencies = ["numpy", "wheel"]
+        general_dependencies = ["numpy", "wheel", "pytest"]
         self.run(_pip_install_cmd(python_executable, *general_dependencies))
 
         # Install xms_dependencies one by one
@@ -339,8 +339,9 @@ class XmsConan2File(ConanFile):
         shutil.copytree(tests_src_dir, tests_dest_dir)
 
         # Run tests using the virtual environment's Python
-        unittest_command = f"{python_executable} -m unittest discover -v -p \"*_pyt.py\" -s {tests_dest_dir}"
-        self.run(unittest_command, cwd=self.build_folder)
+        pytest_ini = os.path.join(self.source_folder, "pytest.ini")
+        pytest_command = f'"{python_executable}" -m pytest -c "{pytest_ini}" {tests_dest_dir} -v'
+        self.run(pytest_command, cwd=self.build_folder)
 
     def export_sources(self):
         """Specify sources to be exported."""


### PR DESCRIPTION
- Change pybind artifact collection to copy source_folder/_package/ instead of build_folder/tests/, capturing the full Python module, tests, and baseline files needed for downstream validation
- Add pytest.ini.jinja template so pytest discovers *_pyt.py test files from the library root via testpaths = _package/tests
- Add .flake8.jinja template with library_name substitution for application-import-names
- Switch run_python_tests() from unittest discover to pytest, using -c to reference the generated pytest.ini as single source of truth
- Update tests for artifact collection and new template generation