### PR TITLE
Fix the existing tests on Windows.

### DIFF
--- a/tests/test_docker_run.py
+++ b/tests/test_docker_run.py
@@ -13,7 +13,7 @@ from xmsconan.ci_tools.docker_run import (
     DOCKER_REGISTRY,
     resolve_docker_image,
 )
-from tests.utils import patch_env
+from .utils import patch_env
 
 
 # --- resolve_docker_image ---

--- a/tests/test_docker_run.py
+++ b/tests/test_docker_run.py
@@ -1,6 +1,5 @@
 """Tests for ci_tools.docker_run."""
 import argparse
-import os
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +13,7 @@ from xmsconan.ci_tools.docker_run import (
     DOCKER_REGISTRY,
     resolve_docker_image,
 )
+from tests.utils import patch_env
 
 
 # --- resolve_docker_image ---
@@ -51,7 +51,7 @@ def test_resolve_image_xvfb_false(tmp_path):
 # --- _build_env_flags ---
 
 
-@patch.dict(os.environ, {
+@patch_env({
     "AQUAPI_URL": "https://x/",
     "AQUAPI_USERNAME": "user",
     "AQUAPI_PASSWORD": "pass",
@@ -68,7 +68,7 @@ def test_build_env_flags_forwards_set_vars():
     assert len(flags) == 6  # 3 vars * 2
 
 
-@patch.dict(os.environ, {}, clear=True)
+@patch_env(clear=True)
 def test_build_env_flags_skips_unset_vars():
     """Produces no flags when env vars are not set."""
     assert _build_env_flags() == []
@@ -149,7 +149,7 @@ def test_docker_publish_builds_correct_command(
         xmsconan_dir=None,
     )
 
-    with patch.dict(os.environ, {}, clear=True):
+    with patch_env(clear=True):
         docker_publish(args)
 
     cmd = mock_run.call_args[0][0]
@@ -185,7 +185,7 @@ def test_docker_publish_mounts_xmsconan_dir(
         xmsconan_dir="/home/user/xmsconan",
     )
 
-    with patch.dict(os.environ, {}, clear=True):
+    with patch_env(clear=True):
         docker_publish(args)
 
     cmd = mock_run.call_args[0][0]
@@ -218,7 +218,7 @@ def test_docker_publish_propagates_exit_code(
         xmsconan_dir=None,
     )
 
-    with patch.dict(os.environ, {}, clear=True):
+    with patch_env(clear=True):
         with pytest.raises(SystemExit) as exc_info:
             docker_publish(args)
     assert exc_info.value.code == 42

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -1,7 +1,7 @@
 """Tests for package_tools.packager."""
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from xmsconan.package_tools.packager import get_current_arch, XmsConanPackager
+from tests.utils import patch_env
 
 
 # --- get_current_arch ---
@@ -42,7 +43,7 @@ def test_configurations_none_before_generate():
 # --- generate_configurations ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_generate_configurations_linux():
     """Linux config has expected shape."""
     p = XmsConanPackager("xmscore")
@@ -55,7 +56,7 @@ def test_generate_configurations_linux():
     assert "buildenv" in base
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_generate_configurations_windows():
     """Windows config uses msvc compiler."""
     p = XmsConanPackager("xmscore")
@@ -65,7 +66,7 @@ def test_generate_configurations_windows():
     assert base["compiler"] == "msvc"
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_generate_configurations_darwin():
     """Verify macOS config sets MACOSX_DEPLOYMENT_TARGET."""
     p = XmsConanPackager("xmscore")
@@ -76,7 +77,7 @@ def test_generate_configurations_darwin():
     assert base["buildenv"].get("MACOSX_DEPLOYMENT_TARGET") == "15.0"
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_generate_configurations_darwin_arm_sets_host_platform():
     """Verify macOS ARM config sets _PYTHON_HOST_PLATFORM to avoid universal2 tag."""
     p = XmsConanPackager("xmscore")
@@ -87,7 +88,7 @@ def test_generate_configurations_darwin_arm_sets_host_platform():
         assert cfg["buildenv"].get("_PYTHON_HOST_PLATFORM") == "macosx-15.0-arm64"
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_generate_configurations_includes_variants():
     """Windows produces base + wchar_t + pybind + testing variants."""
     p = XmsConanPackager("xmscore")
@@ -108,7 +109,7 @@ def test_generate_configurations_includes_variants():
     assert has_testing
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_wchar_t_variants_only_for_msvc():
     """Only msvc compiler gets wchar_t=typedef variants."""
     p = XmsConanPackager("xmscore")
@@ -118,7 +119,7 @@ def test_wchar_t_variants_only_for_msvc():
     assert len(typedef_configs) == 0
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_pybind_variants_exclude_debug():
     """No pybind variant for Debug build_type."""
     p = XmsConanPackager("xmscore")
@@ -129,7 +130,7 @@ def test_pybind_variants_exclude_debug():
         assert cfg["build_type"] != "Debug"
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_testing_variants_added_for_all():
     """Every base config gets a testing variant."""
     p = XmsConanPackager("xmscore")
@@ -142,7 +143,7 @@ def test_testing_variants_added_for_all():
 # --- filter_configurations ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_filter_configurations_by_build_type():
     """Filters by top-level key."""
     p = XmsConanPackager("xmscore")
@@ -154,7 +155,7 @@ def test_filter_configurations_by_build_type():
     assert len(p.configurations) < total
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_filter_configurations_by_option():
     """Filters by nested option value."""
     p = XmsConanPackager("xmscore")
@@ -174,7 +175,7 @@ def test_filter_configurations_noop_when_none():
 # --- create_build_profile ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_create_build_profile_writes_settings_and_options(tmp_path):
     """Profile file contains [settings] and [options] sections."""
     p = XmsConanPackager("xmscore")
@@ -193,7 +194,7 @@ def test_create_build_profile_writes_settings_and_options(tmp_path):
 # --- print_configuration_table ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_print_configuration_table_all(capsys):
     """Default (None) prints all configurations."""
     p = XmsConanPackager("xmscore")
@@ -205,7 +206,7 @@ def test_print_configuration_table_all(capsys):
     assert "gcc" in captured.out
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_print_configuration_table_subset(capsys):
     """Specific index list prints only those rows."""
     p = XmsConanPackager("xmscore")
@@ -216,7 +217,7 @@ def test_print_configuration_table_subset(capsys):
     assert "1" in captured.out  # row number 1 (0-indexed config, 1-indexed display)
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_print_configuration_table_uses_library_name(capsys):
     """Table headers use the actual library name, not a hardcoded value."""
     p = XmsConanPackager("xmsgrid")
@@ -232,7 +233,7 @@ def test_print_configuration_table_uses_library_name(capsys):
 # --- run ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run")
 def test_run_returns_zero_on_success(mock_run):
     """All configurations pass → returns 0."""
@@ -246,7 +247,7 @@ def test_run_returns_zero_on_success(mock_run):
     assert mock_run.call_count >= 1
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch(
     "xmsconan.package_tools.packager.subprocess.run",
     side_effect=subprocess.CalledProcessError(1, "conan"),
@@ -264,7 +265,7 @@ def test_run_returns_failure_count(mock_run):
 # --- upload ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run")
 def test_upload_calls_conan_upload(mock_run):
     """upload() calls conan upload with correct command structure."""
@@ -278,7 +279,7 @@ def test_upload_calls_conan_upload(mock_run):
     assert "xmscore/7.0.0*" in cmd
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch(
     "xmsconan.package_tools.packager.subprocess.run",
     side_effect=subprocess.CalledProcessError(1, "conan"),
@@ -305,7 +306,7 @@ def test_init_artifacts_dir_defaults_to_none():
     assert p._artifacts_dir is None
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_generate_configurations_injects_artifacts_dir(tmp_path):
     """Every configuration gets XMS_TEST_ARTIFACTS_DIR when artifacts_dir set."""
     p = XmsConanPackager("xmscore", artifacts_dir=str(tmp_path))
@@ -315,7 +316,7 @@ def test_generate_configurations_injects_artifacts_dir(tmp_path):
         assert cfg["buildenv"]["XMS_TEST_ARTIFACTS_DIR"] == str(tmp_path)
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_generate_configurations_no_artifacts_dir():
     """XMS_TEST_ARTIFACTS_DIR absent when artifacts_dir not set."""
     p = XmsConanPackager("xmscore")
@@ -328,7 +329,7 @@ def test_generate_configurations_no_artifacts_dir():
 # --- _config_label ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_config_label_testing():
     """Testing config produces 'Release-testing' label."""
     p = XmsConanPackager("xmscore")
@@ -336,7 +337,7 @@ def test_config_label_testing():
     assert p._config_label(combo) == "Release-testing"
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_config_label_pybind():
     """Pybind config produces 'Release-pybind' label."""
     p = XmsConanPackager("xmscore")
@@ -344,7 +345,7 @@ def test_config_label_pybind():
     assert p._config_label(combo) == "Release-pybind"
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_config_label_wchar_typedef():
     """wchar_t=typedef suffix appears in label."""
     p = XmsConanPackager("xmscore")
@@ -352,7 +353,7 @@ def test_config_label_wchar_typedef():
     assert p._config_label(combo) == "Release-testing-wchar_typedef"
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_config_label_plain():
     """Plain config (no testing, no pybind) is just build_type."""
     p = XmsConanPackager("xmscore")
@@ -363,7 +364,7 @@ def test_config_label_plain():
 # --- run with artifacts ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run")
 def test_run_injects_label_into_profile(mock_run, tmp_path):
     """Profile written during run() contains XMS_TEST_ARTIFACTS_LABEL."""
@@ -384,7 +385,7 @@ def test_run_injects_label_into_profile(mock_run, tmp_path):
 # --- test sharding ---
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run")
 def test_run_skips_tests_when_sharding(mock_run, tmp_path):
     """Testing configs get XMS_SKIP_CXX_TESTS=1 when test_shards > 1."""
@@ -401,7 +402,7 @@ def test_run_skips_tests_when_sharding(mock_run, tmp_path):
     assert env.get('XMS_SKIP_CXX_TESTS') == '1'
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run")
 def test_run_no_skip_without_sharding(mock_run):
     """Testing configs run tests normally when test_shards is 0."""
@@ -416,7 +417,7 @@ def test_run_no_skip_without_sharding(mock_run):
     assert env is None
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run", return_value=subprocess.CompletedProcess([], 0))
 def test_run_sharded_tests_invokes_runner(mock_run, tmp_path):
     """After build, runner is invoked N times with GTEST shard env vars."""
@@ -450,7 +451,7 @@ def test_run_sharded_tests_invokes_runner(mock_run, tmp_path):
     assert shard_envs == [('2', '0'), ('2', '1')]
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run")
 def test_run_no_shard_when_shards_is_one(mock_run):
     """test_shards=1 does NOT trigger sharding — tests run normally."""
@@ -465,7 +466,7 @@ def test_run_no_shard_when_shards_is_one(mock_run):
     assert env is None
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run",
        return_value=subprocess.CompletedProcess([], 0))
 def test_run_sharded_tests_handles_subprocess_exception(mock_run, tmp_path):
@@ -494,7 +495,7 @@ def test_run_sharded_tests_handles_subprocess_exception(mock_run, tmp_path):
     assert result > 0  # failures reported, not an unhandled crash
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.package_tools.packager.subprocess.run",
        return_value=subprocess.CompletedProcess([], 0))
 def test_run_sharded_tests_handles_timeout(mock_run, tmp_path):

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -417,8 +417,7 @@ def test_run_no_skip_without_sharding(mock_run):
 
 
 @patch.dict("os.environ", {}, clear=True)
-@patch("xmsconan.package_tools.packager.subprocess.run",
-       return_value=subprocess.CompletedProcess([], 0))
+@patch("xmsconan.package_tools.packager.subprocess.run", return_value=subprocess.CompletedProcess([], 0))
 def test_run_sharded_tests_invokes_runner(mock_run, tmp_path):
     """After build, runner is invoked N times with GTEST shard env vars."""
     artifacts_dir = tmp_path / "artifacts"

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -1,6 +1,7 @@
 """Tests for package_tools.packager."""
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -439,7 +440,7 @@ def test_run_sharded_tests_invokes_runner(mock_run, tmp_path):
     assert result == 0
 
     # First call is conan create, remaining calls are shard runs
-    runner_calls = [c for c in mock_run.call_args_list if str(runner_path) in str(c)]
+    runner_calls = [call for call in mock_run.call_args_list if Path(call.args[0][0]) == runner_path]
     assert len(runner_calls) == 2
 
     # Verify shard env vars

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from xmsconan.package_tools.packager import get_current_arch, XmsConanPackager
-from tests.utils import patch_env
+from .utils import patch_env
 
 
 # --- get_current_arch ---

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -12,6 +12,7 @@ from xmsconan.ci_tools.publish import (
     PublishSteps,
 )
 from xmsconan.generator_tools.version import FALLBACK_VERSION
+from tests.utils import patch_env
 
 
 # --- fixtures ---
@@ -216,7 +217,7 @@ def test_publish_rejects_fallback_version(tmp_path):
 
 @patch("xmsconan.ci_tools.publish.shutil.which", return_value="/usr/bin/xvfb-run")
 @patch("xmsconan.ci_tools.publish.sys.platform", "linux")
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_check_xvfb_true_on_linux(mock_which, tmp_path):
     """Returns True on Linux when ci.xvfb=true and no DISPLAY."""
     toml_file = tmp_path / "build.toml"
@@ -239,7 +240,7 @@ def test_check_xvfb_false_on_macos(tmp_path):
 
 
 @patch("xmsconan.ci_tools.publish.sys.platform", "linux")
-@patch.dict("os.environ", {"DISPLAY": ":0"})
+@patch_env({"DISPLAY": ":0"})
 def test_check_xvfb_false_when_display_set(tmp_path):
     """Returns False when DISPLAY is already set."""
     toml_file = tmp_path / "build.toml"
@@ -251,7 +252,7 @@ def test_check_xvfb_false_when_display_set(tmp_path):
 
 
 @patch("xmsconan.ci_tools.publish.sys.platform", "linux")
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 def test_check_xvfb_false_when_xvfb_not_configured(tmp_path):
     """Returns False when ci.xvfb is not set."""
     toml_file = tmp_path / "build.toml"

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -12,7 +12,7 @@ from xmsconan.ci_tools.publish import (
     PublishSteps,
 )
 from xmsconan.generator_tools.version import FALLBACK_VERSION
-from tests.utils import patch_env
+from .utils import patch_env
 
 
 # --- fixtures ---

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from tests.utils import patch_env
+from .utils import patch_env
 
 WINDOWS = os.name == 'nt'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,76 @@
+"""Tests for tests.utils.patch_env."""
+import os
+
+import pytest
+
+from tests.utils import patch_env
+
+WINDOWS = os.name == 'nt'
+
+
+# --- decorator form ---
+
+
+@pytest.mark.skipif(not WINDOWS, reason="USERPROFILE handling is Windows-only")
+@patch_env({'USERNAME': 'ignored'})
+def test_decorator_preserves_userprofile():
+    """USERPROFILE stays set to the real value when used as a decorator."""
+    assert os.environ['USERPROFILE']
+    assert os.environ['USERNAME'] == 'ignored'
+
+
+# --- context manager form ---
+
+
+@pytest.mark.skipif(not WINDOWS, reason="USERPROFILE handling is Windows-only")
+def test_context_manager_preserves_userprofile():
+    """USERPROFILE stays set to the real value when used as a context manager."""
+    real = os.environ['USERPROFILE']
+    with patch_env({'USERNAME': 'ignored'}):
+        assert os.environ['USERPROFILE'] == real
+        assert os.environ['USERNAME'] == 'ignored'
+
+
+@pytest.mark.skipif(not WINDOWS, reason="USERPROFILE handling is Windows-only")
+def test_clear_still_preserves_userprofile():
+    """clear=True wipes everything else but USERPROFILE survives."""
+    real = os.environ['USERPROFILE']
+    with patch_env({'USERNAME': 'ignored'}, clear=True):
+        assert os.environ['USERPROFILE'] == real
+        assert os.environ['USERNAME'] == 'ignored'
+        assert 'PATH' not in os.environ
+
+
+@pytest.mark.skipif(not WINDOWS, reason="USERPROFILE handling is Windows-only")
+def test_restores_environment_on_exit():
+    """Patched values are reverted after the context manager exits."""
+    original_username = os.environ.get('USERNAME')
+    with patch_env({'USERNAME': 'ignored'}):
+        pass
+    assert os.environ.get('USERNAME') == original_username
+
+
+# --- error cases ---
+
+
+def test_raises_when_userprofile_in_values_dict():
+    """Passing USERPROFILE in the values dict raises ValueError."""
+    with pytest.raises(ValueError, match="USERPROFILE"):
+        patch_env({'USERPROFILE': 'C:\\fake'})
+
+
+def test_raises_when_userprofile_as_kwarg():
+    """Passing USERPROFILE as a keyword argument raises ValueError."""
+    with pytest.raises(ValueError, match="USERPROFILE"):
+        patch_env(USERPROFILE='C:\\fake')
+
+
+# --- non-Windows passthrough ---
+
+
+@pytest.mark.skipif(WINDOWS, reason="tests non-Windows passthrough")
+def test_non_windows_is_plain_passthrough():
+    """On non-Windows, patch_env does not touch USERPROFILE."""
+    with patch_env({'SOME_VAR': 'x'}):
+        assert os.environ['SOME_VAR'] == 'x'
+        assert 'USERPROFILE' not in os.environ

--- a/tests/test_wheel_deploy.py
+++ b/tests/test_wheel_deploy.py
@@ -110,10 +110,7 @@ def test_missing_password_raises(mock_creds):
 
 
 @patch.dict("os.environ", {}, clear=True)
-@patch(
-    "xmsconan.ci_tools.wheel_deploy.subprocess.run",
-    side_effect=subprocess.CalledProcessError(1, "devpi"),
-)
+@patch("xmsconan.ci_tools.wheel_deploy.subprocess.run", side_effect=subprocess.CalledProcessError(1, "devpi"))
 def test_propagates_called_process_error(mock_run):
     """Verify CalledProcessError propagates to caller."""
     with pytest.raises(subprocess.CalledProcessError):

--- a/tests/test_wheel_deploy.py
+++ b/tests/test_wheel_deploy.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from xmsconan.ci_tools.wheel_deploy import wheel_deploy
-from tests.utils import patch_env
+from .utils import patch_env
 
 
 @patch("xmsconan.ci_tools.wheel_deploy.subprocess.run")

--- a/tests/test_wheel_deploy.py
+++ b/tests/test_wheel_deploy.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from xmsconan.ci_tools.wheel_deploy import wheel_deploy
+from tests.utils import patch_env
 
 
 @patch("xmsconan.ci_tools.wheel_deploy.subprocess.run")
@@ -29,13 +30,12 @@ def test_deploy_with_explicit_args(mock_run):
     )
 
 
-@patch.dict(
-    "os.environ",
+@patch_env(
     {
         "AQUAPI_URL": "https://env.example.com/",
         "AQUAPI_USERNAME": "envuser",
         "AQUAPI_PASSWORD": "envpass",
-    },
+    }
 )
 @patch("xmsconan.ci_tools.wheel_deploy.subprocess.run")
 def test_deploy_from_env_vars(mock_run):
@@ -50,7 +50,7 @@ def test_deploy_from_env_vars(mock_run):
     )
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch(
     "xmsconan.ci_tools.wheel_deploy.load_credentials",
     return_value={
@@ -72,7 +72,7 @@ def test_deploy_from_config_file(mock_run, mock_creds):
     )
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch(
     "xmsconan.ci_tools.wheel_deploy.load_credentials",
     return_value={},
@@ -83,7 +83,7 @@ def test_missing_url_raises(mock_creds):
         wheel_deploy()
 
 
-@patch.dict("os.environ", {"AQUAPI_URL": "https://x/"}, clear=True)
+@patch_env({"AQUAPI_URL": "https://x/"}, clear=True)
 @patch(
     "xmsconan.ci_tools.wheel_deploy.load_credentials",
     return_value={},
@@ -94,10 +94,9 @@ def test_missing_username_raises(mock_creds):
         wheel_deploy()
 
 
-@patch.dict(
-    "os.environ",
+@patch_env(
     {"AQUAPI_URL": "https://x/", "AQUAPI_USERNAME": "u"},
-    clear=True,
+    clear=True
 )
 @patch(
     "xmsconan.ci_tools.wheel_deploy.load_credentials",
@@ -109,7 +108,7 @@ def test_missing_password_raises(mock_creds):
         wheel_deploy()
 
 
-@patch.dict("os.environ", {}, clear=True)
+@patch_env(clear=True)
 @patch("xmsconan.ci_tools.wheel_deploy.subprocess.run", side_effect=subprocess.CalledProcessError(1, "devpi"))
 def test_propagates_called_process_error(mock_run):
     """Verify CalledProcessError propagates to caller."""

--- a/tests/test_wheel_repair.py
+++ b/tests/test_wheel_repair.py
@@ -1,5 +1,6 @@
 """Tests for ci_tools.wheel_repair."""
 import os
+from pathlib import Path
 import subprocess
 from unittest.mock import patch
 
@@ -75,7 +76,7 @@ def test_linux_repair(mock_glob, mock_run, mock_rmtree, mock_move):
     # auditwheel repair
     repair_call = mock_run.call_args_list[1]
     assert repair_call[0][0][0] == "auditwheel"
-    assert repair_call[1]["env"]["LD_LIBRARY_PATH"] == "/tmp/wh/libs"
+    assert Path(repair_call[1]["env"]["LD_LIBRARY_PATH"]) == Path("/tmp/wh/libs")
 
     mock_rmtree.assert_called_once_with("/tmp/wh")
     mock_move.assert_called_once_with("/tmp/wh_repaired", "/tmp/wh")
@@ -96,7 +97,7 @@ def test_macos_repair(mock_glob, mock_run, mock_rmtree, mock_move):
     # delocate-wheel
     repair_call = mock_run.call_args_list[1]
     assert repair_call[0][0][0] == "delocate-wheel"
-    assert repair_call[1]["env"]["DYLD_LIBRARY_PATH"] == "/tmp/wh/libs"
+    assert Path(repair_call[1]["env"]["DYLD_LIBRARY_PATH"]) == Path("/tmp/wh/libs")
 
 
 @patch("xmsconan.ci_tools.wheel_repair.shutil.move")

--- a/tests/test_xms_conan2_file.py
+++ b/tests/test_xms_conan2_file.py
@@ -1,5 +1,6 @@
 """Tests for xms_conan2_file."""
 import os
+from pathlib import Path
 import sys
 import sysconfig
 from unittest.mock import MagicMock, patch
@@ -336,13 +337,13 @@ class TestGetPythonCmakeHints:
         """Python3_EXECUTABLE points to sys.executable."""
         obj = object.__new__(XmsConan2File)
         hints = obj._get_python_cmake_hints()
-        assert hints["Python3_EXECUTABLE"] == sys.executable
+        assert Path(hints["Python3_EXECUTABLE"]) == Path(sys.executable)
 
     def test_returns_include_dir(self):
         """Python3_INCLUDE_DIR matches sysconfig include path."""
         obj = object.__new__(XmsConan2File)
         hints = obj._get_python_cmake_hints()
-        assert hints["Python3_INCLUDE_DIR"] == sysconfig.get_path('include')
+        assert Path(hints["Python3_INCLUDE_DIR"]) == Path(sysconfig.get_path('include'))
 
     def test_disables_framework_search(self):
         """Python3_FIND_FRAMEWORK is NEVER to skip macOS framework search."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,30 @@
+"""Helpers for patching os.environ in tests."""
+import os
+from unittest.mock import patch
+
+
+_IS_WINDOWS = os.name == 'nt'
+
+
+def patch_env(values=(), clear=False, **kwargs):
+    """Drop-in for patch.dict(os.environ, ...) that preserves USERPROFILE on Windows.
+
+    Use as a decorator or context manager, same as patch.dict:
+
+        @patch_env({'USERNAME': ''})
+        def test_...(): ...
+
+        with patch_env({'USERNAME': ''}):
+            ...
+
+    On Windows, USERPROFILE is implicitly added to the patched values so it remains
+    set during the test. This matters when the test runs a subprocess or anything
+    resolves the user's home directory. On other platforms this is a plain passthrough.
+    """
+    values_dict = dict(values)
+    if 'USERPROFILE' in values_dict or 'USERPROFILE' in kwargs:
+        # I wasn't sure what semantics to apply in this case and didn't need it.
+        raise ValueError('patch_env does not support passing USERPROFILE explicitly. ')
+    if _IS_WINDOWS:
+        values_dict['USERPROFILE'] = os.environ['USERPROFILE']
+    return patch.dict(os.environ, values_dict, clear=clear, **kwargs)


### PR DESCRIPTION
This mainly boils down to two issues:
- Linux consistently writes paths with forward slashes, while Windows often uses backslashes (and might even escape them).
- - Changed comparisons to be done via `pathlib.Path` instead so they're OS independent.
- pathlib.Path.home() always works on Linux, but depends on environment variables on Windows, which some tests clear.
- - Changed `os.environ` patching to use a helper function that leaves 'USERPROFILE' variable alone.