### PR TITLE
Strengthen test_utils.py assertions from PR #42 review.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,11 @@ from .utils import patch_env
 
 WINDOWS = os.name == 'nt'
 
+# Captured at import time so the decorator-form test can assert equality
+# against the pre-patch USERPROFILE — by the time the wrapped test body runs,
+# patch.dict has already replaced os.environ.
+_REAL_USERPROFILE = os.environ.get('USERPROFILE')
+
 
 # --- decorator form ---
 
@@ -15,7 +20,7 @@ WINDOWS = os.name == 'nt'
 @patch_env({'USERNAME': 'ignored'})
 def test_decorator_preserves_userprofile():
     """USERPROFILE stays set to the real value when used as a decorator."""
-    assert os.environ['USERPROFILE']
+    assert os.environ['USERPROFILE'] == _REAL_USERPROFILE
     assert os.environ['USERNAME'] == 'ignored'
 
 
@@ -36,9 +41,9 @@ def test_clear_still_preserves_userprofile():
     """clear=True wipes everything else but USERPROFILE survives."""
     real = os.environ['USERPROFILE']
     with patch_env({'USERNAME': 'ignored'}, clear=True):
+        assert set(os.environ) == {'USERNAME', 'USERPROFILE'}
         assert os.environ['USERPROFILE'] == real
         assert os.environ['USERNAME'] == 'ignored'
-        assert 'PATH' not in os.environ
 
 
 @pytest.mark.skipif(not WINDOWS, reason="USERPROFILE handling is Windows-only")
@@ -71,6 +76,22 @@ def test_raises_when_userprofile_as_kwarg():
 @pytest.mark.skipif(WINDOWS, reason="tests non-Windows passthrough")
 def test_non_windows_is_plain_passthrough():
     """On non-Windows, patch_env does not touch USERPROFILE."""
+    original = os.environ.get('USERPROFILE')
     with patch_env({'SOME_VAR': 'x'}):
         assert os.environ['SOME_VAR'] == 'x'
-        assert 'USERPROFILE' not in os.environ
+        assert os.environ.get('USERPROFILE') == original
+
+
+# --- additional contract coverage ---
+
+
+def test_kwargs_form_sets_variable():
+    """Non-USERPROFILE kwargs flow through to patch.dict."""
+    with patch_env(SOME_VAR='x'):
+        assert os.environ['SOME_VAR'] == 'x'
+
+
+def test_no_args_is_valid():
+    """patch_env() with no arguments is a valid no-op patch."""
+    with patch_env():
+        pass


### PR DESCRIPTION
Three test-only fixes from the xUnit-pattern review:

- test_decorator_preserves_userprofile now asserts USERPROFILE equals the real captured value (module-level _REAL_USERPROFILE), matching the context-manager twin and detecting any future regression that would corrupt USERPROFILE to a wrong-but-truthy string.
- test_clear_still_preserves_userprofile asserts the post-clear env is exactly {USERNAME, USERPROFILE} instead of "PATH not in env" — the prior assertion silently passed on hosts that didn't set PATH before the patch (Mystery Guest / Resource Optimism on host state).
- test_non_windows_is_plain_passthrough captures the original USERPROFILE and asserts equality, so it does not fail on non-Windows hosts that happen to have USERPROFILE set (WSL crossover, Wine, etc.).

Plus two strictly-additive contract tests:

- test_kwargs_form_sets_variable covers the **kwargs success path (the existing kwargs tests only covered the USERPROFILE-rejection branch).
- test_no_args_is_valid covers the empty-args call path.

No production code changes.