### PR TITLE
Fix FindCxxTest probe under cmake_minimum_required >= 3.21

### DIFF
--- a/xmsconan/generator_tools/templates/CMakeLists.txt.jinja
+++ b/xmsconan/generator_tools/templates/CMakeLists.txt.jinja
@@ -203,6 +203,31 @@ if (BUILD_TESTING)
     list(APPEND EXT_INCLUDE_DIRS ${cxxtest_INCLUDE_DIRS})
 
     if (cxxtest_FOUND)
+        # Pre-cache CXXTEST_PYTHON_TESTGEN_EXECUTABLE before include("FindCxxTest").
+        # The conan cxxtest recipe ships bin/cxxtestgen without the execute bit, and
+        # under cmake_minimum_required >= 3.19 (CMP0109 NEW) CMake's find_program in
+        # FindCxxTest.cmake rejects it. Pre-set cache values aren't subject to the
+        # executability check, so seeding the var here keeps FindCxxTest functional
+        # regardless of cmake_minimum_required value.
+        list(GET cxxtest_INCLUDE_DIRS 0 _xmsconan_cxxtest_include_dir)
+        get_filename_component(_xmsconan_cxxtest_root
+            "${_xmsconan_cxxtest_include_dir}" DIRECTORY)
+        if (WIN32)
+            set(_xmsconan_cxxtestgen_path "${_xmsconan_cxxtest_root}/bin/cxxtestgen.bat")
+        else ()
+            set(_xmsconan_cxxtestgen_path "${_xmsconan_cxxtest_root}/bin/cxxtestgen")
+        endif ()
+        if (NOT EXISTS "${_xmsconan_cxxtestgen_path}")
+            message(FATAL_ERROR
+                "Could not locate cxxtestgen at ${_xmsconan_cxxtestgen_path}")
+        endif ()
+        set(CXXTEST_PYTHON_TESTGEN_EXECUTABLE "${_xmsconan_cxxtestgen_path}"
+            CACHE FILEPATH
+            "Path to cxxtestgen (pre-cached to bypass CMP0109 NEW)" FORCE)
+        unset(_xmsconan_cxxtest_include_dir)
+        unset(_xmsconan_cxxtest_root)
+        unset(_xmsconan_cxxtestgen_path)
+
         include("FindCxxTest")
         include_directories(${CXXTEST_INCLUDE_DIR})
         enable_testing()


### PR DESCRIPTION
The CMake 3.21 minimum bump (introduced in 2.10.0 to enable $<TARGET_RUNTIME_DLLS> in the gtest-branch Windows DLL block) activates CMP0109 NEW, which makes find_program reject files without the execute bit. The conan cxxtest recipe ships bin/cxxtestgen as -rw-rw-rw-, so FindCxxTest.cmake's probe at line 189 now returns NOTFOUND, the literal "-NOTFOUND" string lands in CXXTEST_ADD_TEST's custom_command, and the build explodes when ninja tries to invoke it as a Python script.

Pre-cache CXXTEST_PYTHON_TESTGEN_EXECUTABLE before include("FindCxxTest") so the bundled find_program short- circuits on the cached value -- pre-set cache values are not subject to the CMP0109 executability check. Path is derived from cxxtest_INCLUDE_DIRS (config-agnostic) with a Windows .bat fallback and a FATAL_ERROR if the file is missing.