### PR TITLE
Add Python 3.10 pybind builds alongside 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Methods and Modules used to aid in xmsconan projects.
 
+> **Setting up a new library or trying to remember how a flag works?** See [docs/USAGE.md](docs/USAGE.md) — the consumer-facing guide. The rest of this README is a quick orientation.
+
 ## Installation
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,510 @@
+# xmsconan — Consumer Guide
+
+`xmsconan` is a build-orchestration toolkit for Aquaveo's XMS C++ libraries. You write **one `build.toml`**; xmsconan generates everything else: the Conan recipe, CMake glue, a `build.py` driver, a Python package skeleton, and a CI pipeline. It also ships the runtime helpers those generated files depend on.
+
+This doc is what a consumer needs to know to set up, build, publish, and depend on an xmsconan-managed library.
+
+---
+
+## 1. The mental model
+
+```
+build.toml                       (you write this)
+   │
+   │  xmsconan gen     →   conanfile.py, build.py, CMakeLists.txt,
+   │                       _package/pyproject.toml, .flake8, pytest.ini,
+   │                       xms_conan2_file.py
+   │
+   │  xmsconan ci      →   .github/workflows/<Lib>-CI.yaml  OR  .gitlab-ci.yml
+   │
+   ▼
+python build.py            ← runs the full Conan matrix locally
+xmsconan publish           ← build + repair wheel + deploy to devpi + push to Conan
+```
+
+The C++ source you write lives in `<library_name>/`; tests live alongside. `xmsconan gen` regenerates the *build* files from `build.toml` on each invocation — they are not meant to be edited by hand.
+
+---
+
+## 2. Installation
+
+```bash
+pip install xmsconan
+# or, from the Aquaveo dev index
+pip install xmsconan -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+```
+
+Conan 2 is a hard dependency and is installed transitively. You also need **CMake ≥ 3.21** and a C++17 compiler on the system PATH for actual builds.
+
+---
+
+## 3. Quickstart
+
+```bash
+# 1. Drop a build.toml into the root of your repo (see §5 for the schema)
+# 2. Generate everything that xmsconan owns
+xmsconan gen --version 0.0.0 build.toml
+
+# 3. Generate a CI pipeline (one-time; commit it)
+xmsconan ci  --version 0.0.0 build.toml
+
+# 4. One-shot Conan setup (adds the aquaveo remote, etc.)
+xmsconan conan-setup
+
+# 5. Build the full matrix locally
+python build.py --version 0.0.0 --wheel-dir wheelhouse --artifacts-dir test_artifacts
+```
+
+Everything past step 1 is reproducible — re-run `xmsconan gen` whenever `build.toml` changes.
+
+---
+
+## 4. The unified CLI
+
+All commands live under the `xmsconan` umbrella:
+
+| Command | What it does |
+|---|---|
+| `xmsconan gen` | Render build files (`conanfile.py`, `build.py`, `CMakeLists.txt`, `_package/pyproject.toml`, …) from `build.toml`. |
+| `xmsconan ci` | Render `.github/workflows/<Lib>-CI.yaml` or `.gitlab-ci.yml`. |
+| `xmsconan build` | Run `conan install` + `cmake configure` against a single profile. Used by the generated `build.py`; also useful for one-off configures. |
+| `xmsconan conan-setup` | Detect a Conan profile, add the aquaveo remote, optionally login. |
+| `xmsconan wheel-repair` | Run platform-appropriate wheel repair (auditwheel / delocate / delvewheel). |
+| `xmsconan wheel-deploy` | Upload repaired wheels to devpi. |
+| `xmsconan conan-deploy` | Save / restore / upload Conan packages between CI stages. |
+| `xmsconan publish` | The full release pipeline (gen → build → repair → deploy). |
+
+Run `xmsconan <cmd> --help` for the full flag set. The legacy underscored names (`xmsconan_gen`, `xmsconan_ci`, …) still work and are what the generated CI scripts call.
+
+---
+
+## 5. `build.toml` reference
+
+`build.toml` is the **only** file you author for the build system. It controls everything xmsconan generates.
+
+### 5.1 Required
+
+| Field | Type | Description |
+|---|---|---|
+| `library_name` | string | Conan / CMake project name. e.g. `"xmscore"`. |
+| `description` | string | One-line summary; flows into `conanfile.py` and the wheel metadata. |
+
+### 5.2 Source layout
+
+| Field | Default | Description |
+|---|---|---|
+| `library_sources` | `[]` | C++ implementation files (`.cpp`) for the static library. |
+| `library_headers` | `[]` | Public headers exported to consumers. |
+| `testing_sources` | `[]` | `.cpp` files compiled into the test runner only. |
+| `testing_headers` | `[]` | Test fixture / helper headers (`*.t.h` for cxxtest). |
+| `python_library_sources` | `[]` | C++ files compiled only when `pybind=True`. |
+| `python_library_headers` | `[]` | Headers compiled only when `pybind=True`. |
+| `pybind_sources` | `[]` | Pybind11 binding `.cpp` files. |
+| `pybind_headers` | `[]` | Pybind11 binding headers. |
+
+Paths are interpreted relative to the directory `build.toml` lives in.
+
+### 5.3 Dependencies
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `xms_dependencies` | array[object] | `[]` | XMS sister libraries. Object shape: `{ name = "xmscore", version = "7.0.0", no_python = false }`. `no_python = true` excludes the dep from `_package/pyproject.toml`. |
+| `extra_dependencies` | array[string] | `[]` | Extra Conan deps in `"name/version"` form. |
+| `xms_dependency_options` | object | `{}` | Override an XMS dep's options. e.g. `{ "xmscore" = { "pybind" = false } }`. |
+| `conan_profile_options` | object | `{}` | Per-package options written into the `[options]` section of every generated profile. e.g. `{ "boost" = { "shared" = true } }`. The wildcard `"*"` is supported (e.g. `{ "*" = { "shared" = true } }`); a more specific entry overrides the wildcard. |
+
+Boost (`1.86.0`) and zlib (`1.3.1`) are added automatically by the recipe.
+
+### 5.4 Build configuration
+
+| Field | Default | Description |
+|---|---|---|
+| `testing_framework` | `"cxxtest"` | `"cxxtest"` or `"gtest"`. Selects the test discovery / runner template in CMake. |
+| `python_binding_type` | `"pybind11"` | `"pybind11"` or `"vtk_wrap"`. |
+| `python_namespaced_dir` | derived | The submodule under `xms.<...>`. e.g. `"core"` produces `xms.core`. Defaults to `library_name` minus the `xms` prefix when omitted. |
+| `pybind_root` | `false` | Whether this library hosts the root `xms` namespace. |
+
+### 5.5 CMake escape hatches
+
+| Field | Default | Description |
+|---|---|---|
+| `extra_cmake_text` | `""` | Raw CMake injected near the top of `CMakeLists.txt`. |
+| `post_library_cmake_text` | `""` | Raw CMake appended after the library target is defined. |
+| `extra_export_sources` | `[]` | Additional files / directories Conan exports with the recipe (e.g. `["test_files"]`). |
+
+### 5.6 CI configuration (`[ci]` table)
+
+These drive the CI templates. All optional.
+
+| Field | Default | Description |
+|---|---|---|
+| `ci_type` | — | `"github"` or `"gitlab"`. **Required** for `xmsconan ci`. (Lives at the top level, not under `[ci]`.) |
+| `[ci].windows` | `true` | Emit a Windows job. |
+| `[ci].linux_arm` | `false` | Emit a Linux ARM job (GitHub only). |
+| `[ci].deploy` | `true` | Emit deploy jobs (only run on tag pushes). |
+| `[ci].coverage` | `false` | Emit a coverage job + Pages upload (GitLab only). |
+| `[ci].xvfb` | `false` | Wrap test execution in `xvfb-run` (use for libraries that link X11/VTK). |
+| `[ci].split_tests` | `false` | Split build and C++ test into two stages so testing artifacts can be reused. |
+| `[ci].test_shards` | `0` | When >1 (and `split_tests=true`), shard C++ tests over N parallel jobs using gtest sharding. |
+| `[ci].docker_image` | `""` | Override the build container image (skips the default Aquaveo images). |
+| `[ci].python_versions` | `["3.13"]` | Python versions to build. **Only the Windows matrix fans out across multiple versions** — Linux and macOS always use the highest entry (default `3.13`). Set to `["3.10", "3.13"]` to build a Windows 3.10 wheel + Conan binary in addition to 3.13. See §8. |
+
+### 5.7 Example
+
+```toml
+library_name = "xmscore"
+description = "Support library for XMS products"
+ci_type = "github"
+
+python_namespaced_dir = "core"
+pybind_root = true
+
+xms_dependencies = []
+
+library_sources = [
+    "xmscore/math/math.cpp",
+    "xmscore/misc/StringUtil.cpp",
+]
+library_headers = [
+    "xmscore/math/math.h",
+    "xmscore/misc/StringUtil.h",
+]
+testing_sources = ["xmscore/testing/TestTools.cpp"]
+testing_headers = ["xmscore/math/math.t.h", "xmscore/testing/TestTools.h"]
+pybind_sources  = ["xmscore/python/xmscore_py.cpp"]
+
+[ci]
+linux_arm = true
+python_versions = ["3.10", "3.13"]
+```
+
+---
+
+## 6. What `xmsconan gen` writes
+
+After `xmsconan gen --version X.Y.Z build.toml` you will have (alongside `build.toml`):
+
+```
+.
+├── build.toml
+├── conanfile.py              # Conan recipe (extends XmsConan2File)
+├── build.py                  # Driver: orchestrates the conan-create matrix
+├── CMakeLists.txt            # CMake project — ALL knobs are cache vars
+├── xms_conan2_file.py        # Runtime helper imported by conanfile.py
+├── pytest.ini
+├── .flake8
+└── _package/
+    └── pyproject.toml        # Python package metadata for the wheel
+```
+
+**Don't hand-edit these.** Treat them like generated code: regenerate from `build.toml` on every change. The exception is `xms_conan2_file.py`, which is *copied* (not rendered) — it's part of xmsconan itself and updates whenever you upgrade the `xmsconan` Python package.
+
+---
+
+## 7. The Conan recipe — what it exposes
+
+The generated `conanfile.py` is a thin subclass of `xmsconan.xms_conan2_file.XmsConan2File`. The interesting bits for consumers:
+
+### 7.1 Settings
+
+Standard Conan: `os`, `compiler`, `build_type`, `arch`.
+
+### 7.2 Options
+
+| Option | Values | Default | What it controls |
+|---|---|---|---|
+| `wchar_t` | `"builtin"` / `"typedef"` | `"builtin"` | MSVC `/Zc:wchar_t-` toggle. Only `"typedef"` is built on MSVC (and is excluded from non-MSVC). |
+| `pybind` | `True` / `False` | `False` | Build the Python binding module + wheel. Only built in Release. |
+| `testing` | `True` / `False` | `False` | Build the test runner. Mutually exclusive with `pybind`. |
+| `python_version` | `"3.10"` / `"3.13"` | `"3.13"` | Which Python ABI to target when `pybind=True`. **Dropped from `package_id` when `pybind=False`**, so non-Python builds remain a single binary regardless. |
+
+### 7.3 Required CMake variables (set by the recipe via `tc.variables`)
+
+`PYTHON_TARGET_VERSION`, `IS_PYTHON_BUILD`, `BUILD_TESTING`, `XMS_TESTING_FRAMEWORK`, `XMS_VERSION`. The generated `CMakeLists.txt` already wires these up; only relevant if you write `extra_cmake_text`.
+
+---
+
+## 8. Python version support (3.10 + 3.13)
+
+xmsconan defaults to **Python 3.13 only** everywhere. Some downstream Aquaveo projects (currently Windows-only) need a Python 3.10 build, so the matrix can opt in **just on Windows** to keep the rest of CI simple:
+
+```toml
+[ci]
+python_versions = ["3.10", "3.13"]
+```
+
+What this turns on:
+
+- **Windows CI matrix expands to both versions.** GitHub Actions: `python-version: ["3.10", "3.13"]` on the Windows job only. GitLab: `parallel:matrix` over `PYTHON_TARGET_VERSION` (and the derived `PY_TAG`) on `Conan Build - Windows` and `Conan Deploy - Windows`.
+- **Linux, Linux-ARM, and macOS stay 3.13 only.** Their containers stay on `conan-gcc13-py3.13`, the manylinux wheel-repair stays on `cp313-cp313`, and `Wheel Deploy` / `Conan Deploy - Linux` run as single jobs. No 3.10 docker image is needed.
+- **Conan binaries.** Each Windows pybind variant carries the `python_version` option in its `package_id`, so consumers select `xmscore/X.Y.Z@... pybind=True python_version=3.10` vs `=3.13`. Non-pybind builds drop `python_version` from `package_id`, so testing/plain-library binaries remain a single shared binary regardless.
+- **Wheel output.** Windows produces both `cp310-cp310-win_amd64.whl` and `cp313-cp313-win_amd64.whl`; pip on the consumer side picks the right one.
+
+For local builds (`python build.py`), the packager still fans out per `python_version` when given a list — useful when you're on Windows and want to build both Python wheels at once.
+
+> **Runner / image expectations.** Opt-in assumes the `GLR-py310` GitLab Windows runner tag exists. The Linux/Mac side keeps using existing `conan-gcc13-py3.13` images, so no new images are required.
+
+---
+
+## 9. Local development workflow
+
+### 9.1 Generate, then build everything
+
+```bash
+xmsconan gen      --version 0.0.0 build.toml
+python build.py   --version 0.0.0 --wheel-dir wheelhouse --artifacts-dir test_artifacts
+```
+
+`build.py` flags worth knowing:
+
+| Flag | Effect |
+|---|---|
+| `--filter '{"build_type": "Release"}'` | Restrict to a subset of the matrix. Keys match the configuration dict (`build_type`, `arch`, `compiler`, `options.pybind`, `options.python_version`, …). |
+| `--python-only` | Equivalent to `--filter '{"options": {"pybind": true}}'`. |
+| `--preview` | Print the configuration table and exit. Nothing is built. |
+| `--build-missing` | Pass `--build=missing` to `conan create`. |
+| `--wheel-dir DIR` | After the build, copy each `pybind` package's wheel into `DIR`. With `python_versions=["3.10","3.13"]`, you get one wheel per version. |
+| `--repair` | Run `repair_linux_wheel` after extraction (Docker required). |
+| `--artifacts-dir DIR` | Save per-config test artifacts (LastTest.log, runner binary, `_package/`, `test_files/`) for debugging. |
+| `--test-shards N\|auto` | Run gtest sharding for testing builds. |
+| `--skip-build --upload` | After a successful build, push the matrix to the Conan remote. |
+
+### 9.2 Configure a single profile (for an IDE)
+
+`build.py` runs `conan create` for every config. To get a buildable IDE configuration for one profile (no `conan create`, just install + configure):
+
+```bash
+xmsconan build \
+    --cmake_dir . \
+    --build_dir ../builds/xmscore \
+    --profile VS2022_TESTING \
+    --generator vs2022
+```
+
+Available profile names live under `xmsconan/build_tools/profiles/{debug,release}/`. Append `_d` for debug. Examples:
+
+- `GCC13`, `GCC13_TESTING`, `GCC13_PYBIND`, `GCC13_TESTING_D`
+- `CLANG17_PYBIND`, `CLANG16_TESTING_D`
+- `VS2022`, `VS2022_TESTING`, `VS2022_TESTING_DYNAMIC_D`
+
+You can also pass any explicit profile path with `--profile /path/to/profile`.
+
+### 9.3 Useful build flags
+
+- `--allow-missing-test-files` — Build even when `./test_files/` doesn't exist.
+- `--dry-run` — Print the Conan and CMake commands without running them.
+- `-v` / `-q` — Verbose / quiet output.
+
+---
+
+## 10. Generating CI
+
+```bash
+xmsconan ci --version 0.0.0 build.toml
+```
+
+Emits `.github/workflows/<Lib>-CI.yaml` (when `ci_type = "github"`) or `.gitlab-ci.yml` (when `ci_type = "gitlab"`). **Commit the result** — CI runs against the committed file.
+
+The generated jobs follow the pattern:
+
+1. **Setup Python + Conan** (`xmsconan_conan_setup --remote-url … --login`)
+2. **Generate build files** (`xmsconan_gen --version …`)
+3. **Build** (`python build.py --filter='{"build_type": "<type>"}' --wheel-dir wheelhouse --artifacts-dir test_artifacts`)
+4. **Repair wheel** on Release (`xmsconan_wheel_repair --wheel-dir wheelhouse`)
+5. **On tag pushes:** `xmsconan_wheel_deploy` and `xmsconan_conan_deploy … --upload`
+
+### 10.1 GitHub specifics
+
+- Mac / Linux / Linux-ARM matrices: `build_type × python-version=['3.13']` (single version).
+- **Windows** matrix: `build_type × compiler-version × python-version=ci_python_versions` — only this job expands when you opt in to 3.10.
+- Wheel artifacts: `wheel-${{ runner.os }}` for mac/linux/arm, `wheel-${{ runner.os }}-py${{ matrix.python-version }}` for Windows so the two Python ABIs don't collide.
+- Linux containers stay on `conan-gcc13-py3.13:latest`.
+
+### 10.2 GitLab specifics
+
+- `Conan Build`, `Repair Wheel`, `Wheel Deploy`, `Conan Deploy - Linux`: single-version jobs running on 3.13. No `parallel:matrix`.
+- `Conan Build - Windows`, `Conan Deploy - Windows`: `parallel:matrix` over `PYTHON_TARGET_VERSION`. The matrix also sets `PY_TAG` (`py310` / `py313`) which selects the runner via `image: GLR-${PY_TAG}`.
+- Wheel-repair always runs `cp313-cp313`'s `xmsconan_wheel_repair` inside the manylinux container; auditwheel itself doesn't care about the host Python.
+- Required CI variables: `AQUAPI_URL`, `AQUAPI_USERNAME`, `AQUAPI_PASSWORD` (for wheel deploy).
+
+---
+
+## 11. Wheel repair (`xmsconan wheel-repair`)
+
+Conan-built wheels reference shared libraries from the build environment that won't exist on consumer machines. Wheel repair bundles them in.
+
+```bash
+# Auto-detect the platform from sys.platform
+xmsconan wheel-repair --wheel-dir wheelhouse
+
+# Or be explicit
+xmsconan wheel-repair --wheel-dir wheelhouse --platform linux
+```
+
+What runs per platform:
+
+| Platform | Tool | How libs are found |
+|---|---|---|
+| Linux | `auditwheel repair` (with `patchelf`) | `LD_LIBRARY_PATH={wheel_dir}/libs` |
+| macOS | `delocate-wheel` | `DYLD_LIBRARY_PATH={wheel_dir}/libs` |
+| Windows | `delvewheel repair --namespace-pkg xms` | `--add-path {wheel_dir}/libs` |
+
+`build.py` already populates `wheelhouse/libs/` for you when `--wheel-dir` is set. After repair, the original `wheelhouse/` is replaced with the repaired version (the `libs/` directory is removed).
+
+---
+
+## 12. Wheel deploy (`xmsconan wheel-deploy`)
+
+Uploads `wheelhouse/*.whl` to a devpi index.
+
+```bash
+xmsconan wheel-deploy --wheel-dir wheelhouse
+```
+
+**Credential resolution order** (first non-empty wins):
+
+1. CLI flags: `--url`, `--username`, `--password`
+2. Environment: `AQUAPI_URL`, `AQUAPI_USERNAME`, `AQUAPI_PASSWORD`
+3. `~/.xmsconan.toml` `[aquapi]` section
+
+---
+
+## 13. Conan deploy (`xmsconan conan-deploy`)
+
+Used to ship Conan binaries between CI stages or to upload them at the end. The three modes:
+
+```bash
+# Save the cached package(s) to a tarball
+xmsconan conan-deploy xmscore 7.0.0 --save xmscore-linux-7.0.0.tar.gz
+
+# Restore from a tarball (e.g. produced by an earlier CI stage)
+xmsconan conan-deploy xmscore 7.0.0 --restore xmscore-linux-7.0.0.tar.gz
+
+# Upload the cached package(s) to the aquaveo remote
+xmsconan conan-deploy xmscore 7.0.0 --upload
+
+# Or, end-to-end in one shot
+xmsconan conan-deploy xmscore 7.0.0 --restore xmscore-linux-7.0.0.tar.gz --upload
+```
+
+At least one of `--save / --restore / --upload` is required.
+
+---
+
+## 14. Full release pipeline (`xmsconan publish`)
+
+Wraps the entire flow — useful for CI and for one-off local releases inside a Docker container.
+
+```bash
+# Resolves version from git tag; reads creds from ~/.xmsconan.toml or env
+xmsconan publish --version 7.0.0
+
+# Build only, no upload
+xmsconan publish --version 7.0.0 --no-deploy
+
+# Skip the wheel half / Conan half independently
+xmsconan publish --version 7.0.0 --no-wheel    # Conan-only release
+xmsconan publish --version 7.0.0 --no-conan    # wheel-only release
+
+# Restrict the matrix
+xmsconan publish --version 7.0.0 --filter '{"build_type": "Release"}'
+```
+
+What it runs (with `--no-deploy=false`):
+
+1. `xmsconan_conan_setup --login`
+2. `xmsconan_gen --version <ver> build.toml`
+3. `python build.py --version <ver> --wheel-dir <dir>` (wrapped in `xvfb-run` if `[ci].xvfb=true` and there is no `$DISPLAY` on Linux)
+4. `xmsconan_wheel_repair --wheel-dir <dir>`
+5. `xmsconan_wheel_deploy --wheel-dir <dir>` *(skipped with `--no-wheel`)*
+6. `xmsconan_conan_deploy <library> <version> --upload` *(skipped with `--no-conan`)*
+
+---
+
+## 15. Credentials (`~/.xmsconan.toml`)
+
+Avoid passing credentials on every command:
+
+```toml
+[aquapi]
+url      = "https://public.aquapi.aquaveo.com/aquaveo/dev/"
+username = "your_username"
+password = "your_password"
+
+[conan]
+username = "your_username"
+password = "your_password"
+```
+
+Always overridden by CLI flags / env vars when present. **Don't commit this file.** It's read-only as far as xmsconan is concerned.
+
+---
+
+## 16. Consuming an XMS library from another project
+
+Once a release has been pushed to the Aquaveo Conan remote, downstream Conan consumers depend on it like any other Conan 2 package:
+
+```python
+# downstream conanfile.py
+class MyApp(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def requirements(self):
+        # C++-only consumer — no python_version, no pybind
+        self.requires("xmscore/7.0.0")
+
+    def configure(self):
+        # If you DO want the Python bindings, set both:
+        self.options["xmscore"].pybind = True
+        self.options["xmscore"].python_version = "3.13"   # or "3.10"
+```
+
+Or with explicit options on the install:
+
+```bash
+conan install . \
+    -s build_type=Release \
+    -o "xmscore/*:pybind=True" \
+    -o "xmscore/*:python_version=3.10"
+```
+
+The `xms_dependencies` field in *your* `build.toml` handles the same wiring automatically for sister XMS libraries.
+
+### 16.1 Consuming the wheel (Python-only)
+
+```bash
+pip install xmscore -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+```
+
+Wheels are tagged `cp310-cp310-...` or `cp313-cp313-...`; pip picks the right one based on the active interpreter.
+
+---
+
+## 17. Troubleshooting
+
+- **`auditwheel`/`delocate`/`delvewheel` missing libraries.** Run `build.py --wheel-dir wheelhouse` before repair — that step populates `wheelhouse/libs/`. Repairing without it produces a wheel that loads fine on the build host and crashes everywhere else.
+- **`PYTHON_TARGET_VERSION` mismatch in CMake.** The recipe sets it from the `python_version` Conan option. If you're poking CMake directly, pass `-DPYTHON_TARGET_VERSION=3.13`.
+- **`No pybind package found to extract`.** Means `build.py` ran but no pybind config was built. Check `build.py --preview` to see the matrix; common causes are `--filter` excluding the pybind variant, or every pybind variant having failed.
+- **Dual wheel uploads colliding on devpi.** With `python_versions=["3.10","3.13"]`, wheels carry distinct `cp3XY` tags, so devpi treats them as separate uploads of the same release. No special config required.
+- **Generated CI references a runner that doesn't exist.** Opt-in only matrices Windows, so the only new runner you need is `GLR-py310` (GitLab). If it isn't available, set `python_versions = ["3.13"]` until it is. The Linux/Mac side keeps using the existing 3.13 images.
+
+---
+
+## 18. Reference: shipped Conan profiles
+
+Located under `xmsconan/build_tools/profiles/{debug,release}/`. Use the basename with `xmsconan build --profile`:
+
+| Family | Examples |
+|---|---|
+| GCC | `GCC5`, `GCC7`, `GCC13`, plus `_TESTING`, `_PYBIND`, `_D` (debug) suffixes |
+| Clang | `CLANG9`, `CLANG16`, `CLANG17`, plus `_TESTING`, `_PYBIND`, `_D` |
+| MSVC | `VS2019`, `VS2022`, plus `_TESTING`, `_TESTING_DYNAMIC`, `_D` |
+
+Each suffix means:
+
+- `_D` — Debug build
+- `_TESTING` — Testing-enabled build (cxxtest/gtest runner)
+- `_PYBIND` — Pybind-enabled build (Release only)
+- `_DYNAMIC` (MSVC) — Dynamic CRT (`MD`/`MDd`) instead of static (`MT`/`MTd`)
+
+For a custom mix, write your own profile that `include()`s entries from `xmsconan/build_tools/profiles/base/` and pass it via `--profile /path/to/profile`.

--- a/tests/test_ci_file_generator.py
+++ b/tests/test_ci_file_generator.py
@@ -127,12 +127,83 @@ def test_ci_config_options_passed_to_template(tmp_path):
 
 
 def test_github_linux_uses_container_image(ci_toml, tmp_path):
-    """Linux job uses the Aquaveo Docker container image."""
+    """Linux job uses the Aquaveo 3.13 Docker container image (Linux is 3.13-only)."""
     output_dir = tmp_path / "output"
     generate_ci(str(ci_toml), "1.0.0", str(output_dir))
     ci_file = output_dir / ".github" / "workflows" / "XmsCore-CI.yaml"
     content = ci_file.read_text(encoding="utf-8")
     assert "ghcr.io/aquaveo/conan-gcc13-py3.13:latest" in content
+
+
+def test_github_default_python_version_is_3_13_only(ci_toml, tmp_path):
+    """Without [ci].python_versions every matrix is just 3.13 (3.10 is opt-in)."""
+    output_dir = tmp_path / "output"
+    generate_ci(str(ci_toml), "1.0.0", str(output_dir))
+    content = (output_dir / ".github" / "workflows" / "XmsCore-CI.yaml").read_text(encoding="utf-8")
+    # Flake and Mac use a hard-coded matrix; Windows renders ci_python_versions
+    # via tojson (double-quoted). Linux has no python-version matrix axis.
+    assert content.count("python-version: ['3.13']") == 2  # flake + mac
+    assert content.count('python-version: ["3.13"]') == 1  # windows
+    assert '"3.10"' not in content
+
+
+def test_github_python_versions_opt_in_adds_3_10_only_on_windows(tmp_path):
+    """[ci].python_versions = ["3.10", "3.13"] only expands the Windows matrix."""
+    toml_file = tmp_path / "build.toml"
+    toml_file.write_text(
+        'library_name = "xmscore"\n'
+        'description = "Core"\n'
+        'ci_type = "github"\n'
+        '\n'
+        '[ci]\n'
+        'python_versions = ["3.10", "3.13"]\n',
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    generate_ci(str(toml_file), "1.0.0", str(output_dir))
+    content = (output_dir / ".github" / "workflows" / "XmsCore-CI.yaml").read_text(encoding="utf-8")
+    # Only Windows matrix expands; mac stays 3.13 only.
+    assert content.count('python-version: ["3.10", "3.13"]') == 1
+    assert content.count("python-version: ['3.13']") == 2  # flake + mac
+
+
+def test_gitlab_default_python_version_is_3_13_only(tmp_path):
+    """Without [ci].python_versions GitLab references only 3.13."""
+    toml_file = tmp_path / "build.toml"
+    toml_file.write_text(
+        'library_name = "xmscore"\ndescription = "Core"\nci_type = "gitlab"\n',
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    generate_ci(str(toml_file), "1.0.0", str(output_dir))
+    content = (output_dir / ".gitlab-ci.yml").read_text(encoding="utf-8")
+    assert "PYTHON_TARGET_VERSION: '3.13'" in content
+    assert "PYTHON_TARGET_VERSION: '3.10'" not in content
+
+
+def test_gitlab_python_versions_opt_in_only_fans_out_windows(tmp_path):
+    """[ci].python_versions = ["3.10", "3.13"] only expands the Windows matrix in GitLab."""
+    toml_file = tmp_path / "build.toml"
+    toml_file.write_text(
+        'library_name = "xmscore"\n'
+        'description = "Core"\n'
+        'ci_type = "gitlab"\n'
+        '\n'
+        '[ci]\n'
+        'python_versions = ["3.10", "3.13"]\n',
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    generate_ci(str(toml_file), "1.0.0", str(output_dir))
+    content = (output_dir / ".gitlab-ci.yml").read_text(encoding="utf-8")
+    # Only Windows fans out; PY_TAG variable is windows-only.
+    assert "PY_TAG: 'py310'" in content
+    assert "PY_TAG: 'py313'" in content
+    # Linux jobs are single-version and use a static image.
+    assert "conan-gcc13-py3.13" in content
+    assert "cp313-cp313" in content
+    # Linux jobs are NOT fanned out — so CP_TAG (only the wheel-repair var) is gone.
+    assert "CP_TAG" not in content
 
 
 def test_github_linux_no_setup_python(ci_toml, tmp_path):
@@ -489,7 +560,9 @@ def test_gitlab_ci_test_shards_without_split_tests_no_parallel(tmp_path):
     content = ci_file.read_text(encoding="utf-8")
     assert '"Run C++ Tests":' not in content
     assert "GTEST_TOTAL_SHARDS" not in content
-    assert "parallel:" not in content
+    # The python-version matrix uses `parallel:` too, so check for the
+    # test-sharding form ("parallel: <int>") specifically.
+    assert "parallel: 4" not in content
 
 
 def test_gitlab_ci_split_test_job_uses_xvfb(tmp_path):

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -140,6 +140,57 @@ def test_testing_variants_added_for_all():
     assert len(testing_configs) > 0
 
 
+@patch_env(clear=True)
+def test_pybind_fans_out_per_python_version():
+    """Each pybind variant is duplicated per configured python version."""
+    p = XmsConanPackager("xmscore", python_versions=["3.10", "3.13"])
+    p.generate_configurations(system_platform="linux")
+
+    pybind_configs = [c for c in p.configurations if c["options"].get("pybind") is True]
+    assert pybind_configs, "expected at least one pybind config"
+
+    versions_seen = {c["options"].get("python_version") for c in pybind_configs}
+    assert versions_seen == {"3.10", "3.13"}
+
+    for cfg in pybind_configs:
+        # python_version option must align with the buildenv var so the
+        # generated cmake/profile reads back the same value.
+        assert cfg["buildenv"]["PYTHON_TARGET_VERSION"] == cfg["options"]["python_version"]
+
+
+@patch_env(clear=True)
+def test_non_pybind_configs_have_no_python_version_option():
+    """python_version is omitted from non-pybind builds (recipe drops it from package_id)."""
+    p = XmsConanPackager("xmscore", python_versions=["3.10", "3.13"])
+    p.generate_configurations(system_platform="linux")
+
+    for cfg in p.configurations:
+        if cfg["options"].get("pybind") is True:
+            continue
+        assert "python_version" not in cfg["options"]
+
+
+def test_python_versions_default_when_env_unset(monkeypatch):
+    """python_versions falls back to the default list when env is unset."""
+    monkeypatch.delenv("PYTHON_TARGET_VERSION", raising=False)
+    p = XmsConanPackager("xmscore")
+    assert p.python_versions == XmsConanPackager.DEFAULT_PYTHON_VERSIONS
+
+
+def test_python_versions_honors_env_when_arg_missing(monkeypatch):
+    """A single-version env override collapses the fan-out to that version."""
+    monkeypatch.setenv("PYTHON_TARGET_VERSION", "3.10")
+    p = XmsConanPackager("xmscore")
+    assert p.python_versions == ["3.10"]
+
+
+def test_python_versions_arg_wins_over_env(monkeypatch):
+    """Explicit python_versions kwarg overrides the env."""
+    monkeypatch.setenv("PYTHON_TARGET_VERSION", "3.10")
+    p = XmsConanPackager("xmscore", python_versions=["3.13"])
+    assert p.python_versions == ["3.13"]
+
+
 # --- filter_configurations ---
 
 

--- a/xmsconan/build_helpers.py
+++ b/xmsconan/build_helpers.py
@@ -23,7 +23,7 @@ def get_builder(library_name):
 
     # Add environment variables to build definitions
     xms_version = os.getenv('XMS_VERSION', None)
-    python_target_version = os.getenv('PYTHON_TARGET_VERSION', "3.10")
+    python_target_version = os.getenv('PYTHON_TARGET_VERSION', "3.13")
     ci_commit_tag = os.environ.get('CI_COMMIT_TAG', 'False')  # Gitlab
     release_python = os.getenv('RELEASE_PYTHON', 'False')
     aquapi_username = os.getenv('AQUAPI_USERNAME', None)

--- a/xmsconan/generator_tools/ci_file_generator.py
+++ b/xmsconan/generator_tools/ci_file_generator.py
@@ -97,6 +97,7 @@ def generate_ci(
         "docker_image": ci_config.get("docker_image", ""),
         "ci_split_tests": ci_config.get("split_tests", False),
         "ci_test_shards": ci_config.get("test_shards", 0),
+        "ci_python_versions": list(ci_config.get("python_versions", ["3.13"])),
     }
 
     # Select template and output path

--- a/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
+++ b/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
@@ -96,10 +96,10 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
       # Setup Python
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
@@ -484,12 +484,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-2022]
-        python-version: ['3.13']
+        python-version: << ci_python_versions | tojson >>
         compiler-version: [17]
         build_type: [Release, Debug]
 
     env:
-      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}
+      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}-py${{ matrix.python-version }}
       # Library Variables
       LIBRARY_NAME: << library_name >>
       XMS_VERSION: '0.0.0'
@@ -516,10 +516,10 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
       # Setup Python
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       # Setup Dev Command Prompt env for MSVC
       - name: Setup MSVC env
         uses: ilammy/msvc-dev-cmd@v1
@@ -584,7 +584,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ runner.os }}
+          name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
         if: matrix.build_type == 'Release'
       # Upload wheel to Aquapi

--- a/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
+++ b/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
@@ -40,6 +40,8 @@ Conan Build:
 <% else %>
   image: docker.aquaveo.com/aquaveo/conan-docker/conan-gcc13-py3.13
 <% endif %>
+  variables:
+    PYTHON_TARGET_VERSION: '3.13'
   artifacts:
     expire_in: '1d'
     when: always
@@ -136,7 +138,13 @@ Conan Build:
 <% else %>
   stage: Test
 <% endif %>
-  image: GLR-py313
+  image: GLR-${PY_TAG}
+  parallel:
+    matrix:
+<% for v in ci_python_versions %>
+      - PYTHON_TARGET_VERSION: '<< v >>'
+        PY_TAG: 'py<< v | replace(".", "") >>'
+<% endfor %>
   variables:
     AQUAPI_URL: "https://aquapi.aquaveo.com/aquaveo/dev"
   artifacts:
@@ -155,7 +163,7 @@ Conan Build:
     - xmsconan_conan_setup
     - xmsconan_gen --version ${PACKAGE_VERSION} build.toml
     - python build.py --version ${PACKAGE_VERSION} --artifacts-dir test_artifacts
-    - xmsconan_conan_deploy << library_name >> ${PACKAGE_VERSION} --save .export/<< library_name >>-windows-${PACKAGE_VERSION}.tar.gz
+    - xmsconan_conan_deploy << library_name >> ${PACKAGE_VERSION} --save .export/<< library_name >>-windows-py${PYTHON_TARGET_VERSION}-${PACKAGE_VERSION}.tar.gz
   tags:
     - WinVM
 
@@ -222,9 +230,19 @@ Repair Wheel:
 <% if ci_windows %>
 "Conan Deploy - Windows":
   stage: Deploy
-  image: GLR-py313
-  dependencies:
-    - "Conan Build - Windows"
+  image: GLR-${PY_TAG}
+  parallel:
+    matrix:
+<% for v in ci_python_versions %>
+      - PYTHON_TARGET_VERSION: '<< v >>'
+        PY_TAG: 'py<< v | replace(".", "") >>'
+<% endfor %>
+  needs:
+    - job: "Conan Build - Windows"
+      parallel:
+        matrix:
+          - PYTHON_TARGET_VERSION: $PYTHON_TARGET_VERSION
+      artifacts: true
   artifacts:
     expire_in: '1d'
     paths:
@@ -233,7 +251,7 @@ Repair Wheel:
     - export PACKAGE_VERSION=${CI_COMMIT_TAG:-0.0.0}
     - pip install conan xmsconan>=<< xmsconan_version >> -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_conan_setup
-    - xmsconan_conan_deploy << library_name >> ${PACKAGE_VERSION} --restore .export/<< library_name >>-windows-${PACKAGE_VERSION}.tar.gz --upload
+    - xmsconan_conan_deploy << library_name >> ${PACKAGE_VERSION} --restore .export/<< library_name >>-windows-py${PYTHON_TARGET_VERSION}-${PACKAGE_VERSION}.tar.gz --upload
     - mkdir -p conan_packages
     - cp -r /c/Users/admin/.conan2/p/* conan_packages/ || true
   only:

--- a/xmsconan/generator_tools/templates/_package/pyproject.toml.jinja
+++ b/xmsconan/generator_tools/templates/_package/pyproject.toml.jinja
@@ -8,7 +8,7 @@ version = "{{ version }}"
 description = "{{ description }}"
 license = { text = "BSD 2-Clause License" }
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 keywords = []
 
 authors = [{ name = "Aquaveo" }]
@@ -39,7 +39,7 @@ ext-modules = [
 ]
 {% endif %}
 [tool.cibuildwheel]
-build = "cp313-*"
+build = ["cp310-*", "cp313-*"]
 skip = ["*-musllinux_*"]
 
 [tool.cibuildwheel.windows]

--- a/xmsconan/package_tools/packager.py
+++ b/xmsconan/package_tools/packager.py
@@ -407,7 +407,11 @@ class XmsConanPackager(object):
             version: Package version (default '*' matches any).
 
         Returns:
-            True if at least one wheel was extracted, False otherwise.
+            True only when a wheel was extracted for every version in
+            ``self.python_versions``. Returns False on a partial fan-out
+            (some expected versions missing) or when nothing was extracted,
+            so callers can distinguish "shipped all wheels" from "shipped a
+            subset" before publishing.
         """
         ref = f'{self._library_name}/{version}'
         result = subprocess.run(
@@ -455,7 +459,19 @@ class XmsConanPackager(object):
 
         if not extracted:
             self.printer.print_message('No pybind package found to extract.')
-        return extracted
+            return False
+
+        expected_versions = set(self._python_versions)
+        missing = expected_versions - seen_python_versions
+        if missing:
+            missing_list = ', '.join(sorted(missing))
+            self.printer.print_message(
+                f'Warning: extracted wheels for {sorted(seen_python_versions)} '
+                f'but expected {sorted(expected_versions)} '
+                f'(missing python_version: {missing_list}).'
+            )
+            return False
+        return True
 
     def collect_dependency_libs(self, output_dir):
         """Collect shared libraries from the Conan cache for wheel repair.

--- a/xmsconan/package_tools/packager.py
+++ b/xmsconan/package_tools/packager.py
@@ -69,7 +69,8 @@ class XmsConanPackager(object):
         build_missing=False,
         artifacts_dir=None,
         test_shards=0,
-        profile_options: Optional[dict] = None
+        profile_options: Optional[dict] = None,
+        python_versions: Optional[list] = None,
     ):
         """Initialize the packager.
 
@@ -84,6 +85,12 @@ class XmsConanPackager(object):
                 configuration's profile, e.g. {'boost': {'shared': True}}.
                 Each dep/opt pair is emitted as a `pkg/*:opt=value` line in the
                 profile's [options] section.
+            python_versions: Python versions to fan out pybind builds across
+                (e.g. ["3.10", "3.13"]). When None, falls back to the
+                ``PYTHON_TARGET_VERSION`` environment variable (single value)
+                or the default list ["3.10", "3.13"]. Each pybind variant is
+                duplicated per version with the matching ``python_version``
+                Conan option and ``PYTHON_TARGET_VERSION`` buildenv set.
         """
         self._library_name = library_name
         self._conanfile_path = conanfile_path
@@ -92,6 +99,7 @@ class XmsConanPackager(object):
         self._artifacts_dir = os.path.abspath(artifacts_dir) if artifacts_dir else None
         self._test_shards = test_shards
         self._profile_options = profile_options or {}
+        self._python_versions = self._resolve_python_versions(python_versions)
         self.printer = Printer()
         self._temp_dir = tempfile.TemporaryDirectory()
         self._temp_dir_path = self._temp_dir.name
@@ -99,6 +107,23 @@ class XmsConanPackager(object):
     def __del__(self):
         """Cleanup the temporary directory."""
         self._temp_dir.cleanup()
+
+    DEFAULT_PYTHON_VERSIONS = ["3.13"]
+
+    @classmethod
+    def _resolve_python_versions(cls, python_versions):
+        """Resolve the python_versions list from the constructor arg or env."""
+        if python_versions:
+            return list(python_versions)
+        env_version = os.getenv('PYTHON_TARGET_VERSION')
+        if env_version:
+            return [env_version]
+        return list(cls.DEFAULT_PYTHON_VERSIONS)
+
+    @property
+    def python_versions(self):
+        """Get the list of python versions pybind builds will fan out across."""
+        return list(self._python_versions)
 
     @property
     def library_name(self):
@@ -136,7 +161,10 @@ class XmsConanPackager(object):
         combinations = [dict(zip(keys, combination)) for combination in itertools.product(*values)]
 
         xms_version = os.getenv('XMS_VERSION', None)
-        python_target_version = os.getenv('PYTHON_TARGET_VERSION', "3.13")
+        # Non-pybind builds don't depend on the python version (the recipe
+        # drops it from package_id), but PYTHON_TARGET_VERSION still feeds
+        # CMake / pre-conan2 paths, so seed it with the highest version.
+        default_python_version = self._python_versions[-1]
         ci_commit_tag = os.environ.get('CI_COMMIT_TAG', 'False')  # Gitlab
         release_python = os.getenv('RELEASE_PYTHON', 'False')
         aquapi_username = os.getenv('AQUAPI_USERNAME', None)
@@ -154,7 +182,7 @@ class XmsConanPackager(object):
             }
             combination['buildenv'] = {
                 'XMS_VERSION': xms_version,
-                'PYTHON_TARGET_VERSION': python_target_version,
+                'PYTHON_TARGET_VERSION': default_python_version,
                 'CI_COMMIT_TAG': ci_commit_tag,
                 'RELEASE_PYTHON': release_python,
                 'AQUAPI_USERNAME': aquapi_username,
@@ -187,11 +215,14 @@ class XmsConanPackager(object):
                     (combination['compiler'] != 'msvc' or combination['compiler.runtime'] in ['dynamic']):
                 if combination['compiler'] == 'msvc' and int(combination['compiler.version']) <= 12:
                     continue
-                pybind_options = copy.deepcopy(combination)
-                pybind_options['options'].update({
-                    'pybind': True,
-                })
-                pybind_updated_builds.append(pybind_options)
+                for py_version in self._python_versions:
+                    pybind_options = copy.deepcopy(combination)
+                    pybind_options['options'].update({
+                        'pybind': True,
+                        'python_version': py_version,
+                    })
+                    pybind_options['buildenv']['PYTHON_TARGET_VERSION'] = py_version
+                    pybind_updated_builds.append(pybind_options)
 
         testing_updated_builds = []
         for combination in combinations:
@@ -241,7 +272,8 @@ class XmsConanPackager(object):
         if opts.get('testing'):
             parts.append('testing')
         elif opts.get('pybind'):
-            parts.append('pybind')
+            py_version = opts.get('python_version')
+            parts.append(f'pybind-py{py_version}' if py_version else 'pybind')
         if opts.get('wchar_t') == 'typedef':
             parts.append('wchar_typedef')
         return '-'.join(parts)
@@ -363,14 +395,19 @@ class XmsConanPackager(object):
         self.printer.print_message('All packages uploaded successfully.')
 
     def extract_wheel(self, output_dir, version='*'):
-        """Extract the pre-built wheel from the pybind Conan package.
+        """Extract pre-built wheels from every pybind Conan package.
+
+        With multiple ``python_version`` options there can be more than one
+        pybind binary in the cache (e.g. one for 3.10 and one for 3.13);
+        every distinct ``python_version`` value yields a separate wheel and
+        all of them are copied to ``output_dir``.
 
         Args:
-            output_dir: Directory to copy the .whl file into.
+            output_dir: Directory to copy the .whl files into.
             version: Package version (default '*' matches any).
 
         Returns:
-            True if a wheel was extracted, False otherwise.
+            True if at least one wheel was extracted, False otherwise.
         """
         ref = f'{self._library_name}/{version}'
         result = subprocess.run(
@@ -382,18 +419,24 @@ class XmsConanPackager(object):
             return False
 
         data = json.loads(result.stdout)
-        # Collect all pybind candidates with their revision timestamps
-        # so we can pick the most recently built one.
+        # Collect all pybind candidates with their revision timestamps so we
+        # can pick the most recent one per python_version.
         candidates = []
         for exact_ref, cache in data.get('Local Cache', {}).items():
             for rev in cache.get('revisions', {}).values():
                 ts = rev.get('timestamp', 0)
                 for pid, pinfo in rev.get('packages', {}).items():
-                    if pinfo.get('info', {}).get('options', {}).get('pybind') == 'True':
-                        candidates.append((ts, exact_ref, pid))
+                    options = pinfo.get('info', {}).get('options', {})
+                    if options.get('pybind') == 'True':
+                        py_version = options.get('python_version', '')
+                        candidates.append((ts, py_version, exact_ref, pid))
         candidates.sort(reverse=True)  # newest first
 
-        for _ts, exact_ref, pid in candidates:
+        seen_python_versions = set()
+        extracted = False
+        for _ts, py_version, exact_ref, pid in candidates:
+            if py_version in seen_python_versions:
+                continue
             path_result = subprocess.run(
                 ['conan', 'cache', 'path', f'{exact_ref}:{pid}'],
                 capture_output=True, text=True
@@ -402,15 +445,17 @@ class XmsConanPackager(object):
             dist_dir = os.path.join(pkg_dir, 'dist')
             if not os.path.isdir(dist_dir):
                 continue
+            seen_python_versions.add(py_version)
             os.makedirs(output_dir, exist_ok=True)
             for fname in os.listdir(dist_dir):
                 if fname.endswith('.whl'):
                     shutil.copy2(os.path.join(dist_dir, fname), output_dir)
                     self.printer.print_message(f'Extracted {fname} to {output_dir}')
-            return True
+                    extracted = True
 
-        self.printer.print_message('No pybind package found to extract.')
-        return False
+        if not extracted:
+            self.printer.print_message('No pybind package found to extract.')
+        return extracted
 
     def collect_dependency_libs(self, output_dir):
         """Collect shared libraries from the Conan cache for wheel repair.
@@ -443,7 +488,7 @@ class XmsConanPackager(object):
                         count += 1
         self.printer.print_message(f'Collected {count} shared libraries to {output_dir}')
 
-    def repair_linux_wheel(self, wheel_dir):
+    def repair_linux_wheel(self, wheel_dir, python_version=None):
         """Repair a Linux wheel for manylinux_2_28 using a Docker container.
 
         Runs auditwheel inside quay.io/pypa/manylinux_2_28 to produce a
@@ -451,6 +496,12 @@ class XmsConanPackager(object):
 
         Args:
             wheel_dir: Directory containing the .whl file and libs/ subdirectory.
+            python_version: Python version (e.g. "3.10") used to pick the
+                manylinux ``cpXY-cpXY`` interpreter that runs auditwheel.
+                When None, the highest version from ``self.python_versions``
+                is used. Auditwheel itself is python-version-agnostic for
+                repairing, but the manylinux image needs *some* installed
+                interpreter to run pip.
         """
         machine = platform.machine().lower()
         arch_map = {
@@ -463,13 +514,17 @@ class XmsConanPackager(object):
         image = f'quay.io/pypa/manylinux_2_28_{arch}'
         abs_wheel_dir = os.path.abspath(wheel_dir)
 
-        self.printer.print_message(f'Repairing wheel with auditwheel in {image}')
+        if python_version is None:
+            python_version = self._python_versions[-1]
+        cp_tag = f'cp{python_version.replace(".", "")}'
+
+        self.printer.print_message(f'Repairing wheel with auditwheel in {image} (python {python_version})')
         cmd = [
             'docker', 'run', '--rm',
             '-v', f'{abs_wheel_dir}:/wheels',
             image,
             'bash', '-c',
-            'export PATH="/opt/python/cp313-cp313/bin:$PATH" && '
+            f'export PATH="/opt/python/{cp_tag}-{cp_tag}/bin:$PATH" && '
             'pip install auditwheel patchelf && '
             'LD_LIBRARY_PATH=/wheels/libs auditwheel repair /wheels/*.whl '
             '-w /wheels_repaired && '
@@ -522,14 +577,14 @@ class XmsConanPackager(object):
 
         headers = ["#", "cppstd", "runtime", "build_type", "compiler", "compiler.version", "arch",
                    f"{self._library_name}:wchar_t", f"{self._library_name}:pybind",
-                   f"{self._library_name}:testing"]
+                   f"{self._library_name}:testing", f"{self._library_name}:python_version"]
         table = []
 
         # Create the header row
         header_row = "| {:^3} | {:^8} | {:^8} | {:^12} | {:^14} | {:^18} | {:^6} |" \
-                     " {:^17} | {:^16} | {:^17} |".format(*headers)
+                     " {:^17} | {:^16} | {:^17} | {:^15} |".format(*headers)
         separator = "+-----+----------+----------+--------------+----------------+--------------------+--------+" \
-                    "-------------------+------------------+-------------------+"
+                    "-------------------+------------------+-------------------+-----------------+"
 
         # Add the header row and separator to the table
         table.append(separator)
@@ -542,7 +597,9 @@ class XmsConanPackager(object):
             wchar_t_option = config['options'].get('wchar_t', False)
             pybind_option = config['options'].get('pybind', False)
             testing_option = config['options'].get('testing', False)
-            row = "| {:^3} | {:^8} | {:^8} | {:^12} | {:^14} | {:^18} | {:^6} | {:^17} | {:^16} | {:^17} |".format(
+            python_version_option = config['options'].get('python_version', '-')
+            row = ("| {:^3} | {:^8} | {:^8} | {:^12} | {:^14} | {:^18} | {:^6} |"
+                   " {:^17} | {:^16} | {:^17} | {:^15} |").format(
                 i + 1,
                 config.get("compiler.cppstd", ""),
                 config.get("compiler.runtime", ""),
@@ -553,6 +610,7 @@ class XmsConanPackager(object):
                 wchar_t_option,
                 'True' if pybind_option else 'False',
                 'True' if testing_option else 'False',
+                python_version_option,
             )
             table.append(row)
             table.append(separator)

--- a/xmsconan/xms_conan2_file.py
+++ b/xmsconan/xms_conan2_file.py
@@ -35,6 +35,7 @@ class XmsConan2File(ConanFile):
         "wchar_t": ["builtin", "typedef"],
         "pybind": [True, False],
         "testing": [True, False],
+        "python_version": ["3.10", "3.13"],
     }
     xms_dependencies = []
     extra_dependencies = []
@@ -48,6 +49,7 @@ class XmsConan2File(ConanFile):
         'wchar_t': 'builtin',
         'pybind': False,
         'testing': False,
+        'python_version': '3.13',
     }
 
     def requirements(self):
@@ -101,6 +103,15 @@ class XmsConan2File(ConanFile):
             dep_opts = self.xms_dependency_options.get(dep_name, {})
             self.options[dep_name].pybind = dep_opts.get('pybind', self.options.pybind)
             self.options[dep_name].testing = dep_opts.get('testing', self.options.testing)
+            if 'python_version' in self.options[dep_name]:
+                self.options[dep_name].python_version = dep_opts.get(
+                    'python_version', self.options.python_version
+                )
+
+    def package_id(self):
+        """Drop python_version from the package_id when not building Python bindings."""
+        if not self.info.options.pybind:
+            del self.info.options.python_version
 
     def layout(self):
         """The layout method."""
@@ -131,7 +142,7 @@ class XmsConan2File(ConanFile):
 
         # Version Info
         tc.variables["XMS_VERSION"] = '{}'.format(self.version)
-        tc.variables["PYTHON_TARGET_VERSION"] = self.buildenv.vars(self).get("PYTHON_TARGET_VERSION", "3.13")
+        tc.variables["PYTHON_TARGET_VERSION"] = str(self.options.python_version)
 
         if self.options.pybind:
             for key, value in self._get_python_cmake_hints().items():
@@ -158,7 +169,7 @@ class XmsConan2File(ConanFile):
 
         # Version Info
         variables["XMS_VERSION"] = '{}'.format(self.version)
-        variables["PYTHON_TARGET_VERSION"] = self.buildenv.vars(self).get("PYTHON_TARGET_VERSION", "3.13")
+        variables["PYTHON_TARGET_VERSION"] = str(self.options.python_version)
 
         if self.options.pybind:
             variables.update(self._get_python_cmake_hints())
@@ -334,7 +345,7 @@ class XmsConan2File(ConanFile):
         """Run Python tests in a virtual environment and optionally upload."""
         build_venv_dir = os.path.join(self.build_folder, "venv")
         tests_dest_dir = os.path.join(self.build_folder, "tests")
-        python_target_version = self.buildenv.vars(self).get("PYTHON_TARGET_VERSION", "3.13")
+        python_target_version = str(self.options.python_version)
 
         if sys.platform == "win32":
             python_executable = os.path.join(build_venv_dir, "Scripts", "python.exe")


### PR DESCRIPTION
## Summary
- Adds a `python_version` Conan option and packager-level fan-out so pybind variants are built once per configured Python version, with `python_version` dropped from `package_id` for non-pybind builds.
- Surfaces `[ci].python_versions` in `build.toml`; the GitHub and GitLab Windows matrices fan out across the listed versions, while Linux/macOS stay pinned to 3.13 for now.
- Drops the `requires-python` floor in the generated `pyproject.toml` to 3.10 and updates `cibuildwheel` to build both `cp310-*` and `cp313-*`.
- Adds `docs/USAGE.md` and links it from the README.

## Test plan
- [ ] `pytest tests/test_packager.py tests/test_ci_file_generator.py`
- [ ] Generate a sample `.gitlab-ci.yml` / GitHub workflow with `[ci].python_versions = ["3.10", "3.13"]` and confirm only the Windows jobs fan out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)