### PR TITLE
Address follow-up cleanup from PR #46 (issue #47)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -240,7 +240,7 @@ What this turns on:
 - **Conan binaries.** Each Windows pybind variant carries the `python_version` option in its `package_id`, so consumers select `xmscore/X.Y.Z@... pybind=True python_version=3.10` vs `=3.13`. Non-pybind builds drop `python_version` from `package_id`, so testing/plain-library binaries remain a single shared binary regardless.
 - **Wheel output.** Windows produces both `cp310-cp310-win_amd64.whl` and `cp313-cp313-win_amd64.whl`; pip on the consumer side picks the right one.
 
-For local builds (`python build.py`), the packager still fans out per `python_version` when given a list — useful when you're on Windows and want to build both Python wheels at once.
+For local builds (`python build.py`), the matrix is single-version: it uses `PYTHON_TARGET_VERSION` from the environment if set, otherwise `3.13`. Per-`python_version` fan-out is currently a CI/Windows-only feature; to build both wheels locally you'd need to invoke `python build.py` once per version (or construct `XmsConanPackager` directly with `python_versions=["3.10", "3.13"]`).
 
 > **Runner / image expectations.** Opt-in assumes the `GLR-py310` GitLab Windows runner tag exists. The Linux/Mac side keeps using existing `conan-gcc13-py3.13` images, so no new images are required.
 

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -229,8 +229,7 @@ def test_python_versions_rejects_malformed_env():
 
 @patch_env(clear=True)
 def test_default_python_version_uses_max_not_list_order():
-    """Non-pybind buildenv seeds PYTHON_TARGET_VERSION with the highest version
-    regardless of how python_versions is ordered."""
+    """Non-pybind buildenv seeds PYTHON_TARGET_VERSION with the highest version regardless of list order."""
     p = XmsConanPackager("xmscore", python_versions=["3.13", "3.10"])
     p.generate_configurations(system_platform="linux")
     non_pybind = [c for c in p.configurations if not c["options"].get("pybind")]

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -191,6 +191,54 @@ def test_python_versions_arg_wins_over_env(monkeypatch):
     assert p.python_versions == ["3.13"]
 
 
+@patch_env(clear=True)
+@pytest.mark.parametrize("bogus", ["3", "3.x", "py3.13", "", "3.10.0"])
+def test_python_versions_rejects_malformed_entries(bogus):
+    """Non-X.Y strings fail fast instead of silently propagating."""
+    with pytest.raises(ValueError):
+        XmsConanPackager("xmscore", python_versions=["3.13", bogus])
+
+
+@patch_env(clear=True)
+def test_python_versions_rejects_non_string_entries():
+    """Numeric entries are caught even though they look version-ish."""
+    with pytest.raises(ValueError):
+        XmsConanPackager("xmscore", python_versions=[3.13])
+
+
+@patch_env(clear=True)
+def test_python_versions_rejects_non_list():
+    """A bare string is a common mistake but is rejected explicitly."""
+    with pytest.raises(ValueError):
+        XmsConanPackager("xmscore", python_versions="3.13")
+
+
+@patch_env(clear=True)
+def test_python_versions_empty_list_falls_back_to_default():
+    """An empty list is treated like None — fall back to env / default."""
+    p = XmsConanPackager("xmscore", python_versions=[])
+    assert p.python_versions == XmsConanPackager.DEFAULT_PYTHON_VERSIONS
+
+
+@patch_env({"PYTHON_TARGET_VERSION": "py313"}, clear=True)
+def test_python_versions_rejects_malformed_env():
+    """An obviously-broken PYTHON_TARGET_VERSION is rejected too."""
+    with pytest.raises(ValueError):
+        XmsConanPackager("xmscore")
+
+
+@patch_env(clear=True)
+def test_default_python_version_uses_max_not_list_order():
+    """Non-pybind buildenv seeds PYTHON_TARGET_VERSION with the highest version
+    regardless of how python_versions is ordered."""
+    p = XmsConanPackager("xmscore", python_versions=["3.13", "3.10"])
+    p.generate_configurations(system_platform="linux")
+    non_pybind = [c for c in p.configurations if not c["options"].get("pybind")]
+    assert non_pybind, "expected at least one non-pybind config"
+    for cfg in non_pybind:
+        assert cfg["buildenv"]["PYTHON_TARGET_VERSION"] == "3.13"
+
+
 # --- filter_configurations ---
 
 

--- a/tests/test_xms_conan2_file.py
+++ b/tests/test_xms_conan2_file.py
@@ -330,6 +330,102 @@ class TestSkipCxxTests:
         cmake.test.assert_called_once()
 
 
+class TestPackageId:
+    """Verify package_id drops python_version for non-pybind builds."""
+
+    class _InfoOptions:
+        """Plain stub so that ``del`` actually removes the attribute."""
+
+        def __init__(self, pybind):
+            self.pybind = pybind
+            self.python_version = "3.13"
+
+    def _make_obj(self, pybind):
+        obj = object.__new__(XmsConan2File)
+        obj.info = MagicMock()
+        obj.info.options = self._InfoOptions(pybind=pybind)
+        return obj
+
+    def test_drops_python_version_when_not_pybind(self):
+        """package_id removes python_version from info.options when pybind is False."""
+        obj = self._make_obj(pybind=False)
+        obj.package_id()
+        assert not hasattr(obj.info.options, "python_version")
+
+    def test_keeps_python_version_for_pybind(self):
+        """package_id keeps python_version on info.options when pybind is True."""
+        obj = self._make_obj(pybind=True)
+        obj.package_id()
+        assert obj.info.options.python_version == "3.13"
+
+
+class TestXmsDependencyPythonVersionPropagation:
+    """Verify configure() propagates python_version into each xms_dependency.
+
+    Consumers rely on the XmsConan2File option flowing into the dep options so
+    that a top-level pybind=True / python_version=3.10 build wires every sister
+    library to the matching ABI.
+    """
+
+    _SENTINEL = object()
+
+    def _make_obj(self, dep_has_python_version, dep_options_override=None):
+        """Construct an obj whose configure() will iterate xms_dependencies."""
+        obj = object.__new__(XmsConan2File)
+        obj.xms_dependencies = ["foo/1.0"]
+        obj.xms_dependency_options = (
+            {"foo": dep_options_override} if dep_options_override else {}
+        )
+
+        # Top-level options
+        obj.options = MagicMock()
+        obj.options.pybind = True
+        obj.options.testing = False
+        obj.options.python_version = "3.10"
+
+        # Dep options accessed via self.options[dep_name]
+        dep_opts = MagicMock()
+        # Pre-set python_version to a sentinel so we can detect whether
+        # configure() actually overwrote it.
+        dep_opts.python_version = self._SENTINEL
+        contains_keys = {"python_version"} if dep_has_python_version else set()
+        dep_opts.__contains__.side_effect = lambda key: key in contains_keys
+
+        boost_opts = MagicMock()
+        obj.options.__getitem__.side_effect = (
+            lambda key: dep_opts if key == "foo" else boost_opts
+        )
+
+        # Settings — pick something configure() doesn't reject.
+        obj.settings = MagicMock()
+        obj.settings.os = MagicMock(__str__=lambda s: "Linux")
+        obj.settings.compiler = MagicMock(__str__=lambda s: "gcc")
+        obj.settings.compiler.version = MagicMock(value="13.0")
+
+        return obj, dep_opts
+
+    def test_propagates_top_level_python_version(self):
+        """Without a per-dep override, the top-level python_version flows through."""
+        obj, dep_opts = self._make_obj(dep_has_python_version=True)
+        obj.configure()
+        assert dep_opts.python_version == "3.10"
+
+    def test_per_dep_override_wins(self):
+        """An xms_dependency_options entry overrides the top-level value."""
+        obj, dep_opts = self._make_obj(
+            dep_has_python_version=True,
+            dep_options_override={"python_version": "3.13"},
+        )
+        obj.configure()
+        assert dep_opts.python_version == "3.13"
+
+    def test_skipped_when_dep_lacks_option(self):
+        """Deps that don't expose python_version aren't touched."""
+        obj, dep_opts = self._make_obj(dep_has_python_version=False)
+        obj.configure()
+        assert dep_opts.python_version is self._SENTINEL
+
+
 class TestGetPythonCmakeHints:
     """Verify _get_python_cmake_hints returns correct FindPython3 hints."""
 

--- a/xmsconan/package_tools/packager.py
+++ b/xmsconan/package_tools/packager.py
@@ -5,6 +5,7 @@ import itertools
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -70,7 +71,7 @@ class XmsConanPackager(object):
         artifacts_dir=None,
         test_shards=0,
         profile_options: Optional[dict] = None,
-        python_versions: Optional[list] = None,
+        python_versions: Optional[list[str]] = None,
     ):
         """Initialize the packager.
 
@@ -106,19 +107,56 @@ class XmsConanPackager(object):
 
     def __del__(self):
         """Cleanup the temporary directory."""
-        self._temp_dir.cleanup()
+        # Constructor validation can raise before _temp_dir is assigned.
+        temp_dir = getattr(self, '_temp_dir', None)
+        if temp_dir is not None:
+            temp_dir.cleanup()
 
     DEFAULT_PYTHON_VERSIONS = ["3.13"]
+    _PYTHON_VERSION_RE = re.compile(r'^\d+\.\d+$')
 
     @classmethod
-    def _resolve_python_versions(cls, python_versions):
-        """Resolve the python_versions list from the constructor arg or env."""
-        if python_versions:
-            return list(python_versions)
+    def _resolve_python_versions(cls, python_versions: Optional[list[str]]):
+        """Resolve the python_versions list from the constructor arg or env.
+
+        Validation here only checks the *shape* of each entry (a ``"X.Y"``
+        string). It does not check membership in the recipe's allowed set
+        (see ``XmsConan2File.options["python_version"]``); a syntactically
+        valid but unsupported version like ``"3.11"`` will pass this gate
+        and fail later when Conan rejects the option.
+
+        Raises:
+            ValueError: When ``python_versions`` is not iterable, contains a
+                non-string entry, or contains a string that is not in
+                ``"X.Y"`` form.
+        """
+        if python_versions is not None:
+            if not isinstance(python_versions, (list, tuple)):
+                raise ValueError(
+                    f'python_versions must be a list or tuple, got {type(python_versions).__name__}'
+                )
+            if python_versions:
+                cleaned = []
+                for entry in python_versions:
+                    if not isinstance(entry, str) or not cls._PYTHON_VERSION_RE.match(entry):
+                        raise ValueError(
+                            f'python_versions entries must be "X.Y" strings, got {entry!r}'
+                        )
+                    cleaned.append(entry)
+                return cleaned
         env_version = os.getenv('PYTHON_TARGET_VERSION')
         if env_version:
+            if not cls._PYTHON_VERSION_RE.match(env_version):
+                raise ValueError(
+                    f'PYTHON_TARGET_VERSION must be an "X.Y" string, got {env_version!r}'
+                )
             return [env_version]
         return list(cls.DEFAULT_PYTHON_VERSIONS)
+
+    @staticmethod
+    def _highest_python_version(versions):
+        """Return the version string with the largest (major, minor) tuple."""
+        return max(versions, key=lambda v: tuple(int(p) for p in v.split('.')))
 
     @property
     def python_versions(self):
@@ -164,7 +202,7 @@ class XmsConanPackager(object):
         # Non-pybind builds don't depend on the python version (the recipe
         # drops it from package_id), but PYTHON_TARGET_VERSION still feeds
         # CMake / pre-conan2 paths, so seed it with the highest version.
-        default_python_version = self._python_versions[-1]
+        default_python_version = self._highest_python_version(self._python_versions)
         ci_commit_tag = os.environ.get('CI_COMMIT_TAG', 'False')  # Gitlab
         release_python = os.getenv('RELEASE_PYTHON', 'False')
         aquapi_username = os.getenv('AQUAPI_USERNAME', None)
@@ -504,20 +542,17 @@ class XmsConanPackager(object):
                         count += 1
         self.printer.print_message(f'Collected {count} shared libraries to {output_dir}')
 
-    def repair_linux_wheel(self, wheel_dir, python_version=None):
+    def repair_linux_wheel(self, wheel_dir):
         """Repair a Linux wheel for manylinux_2_28 using a Docker container.
 
         Runs auditwheel inside quay.io/pypa/manylinux_2_28 to produce a
-        portable manylinux wheel. Requires Docker.
+        portable manylinux wheel. Requires Docker. Auditwheel is itself
+        python-version-agnostic for the repair step, but the manylinux
+        image needs *some* installed interpreter to run pip; we use the
+        highest version from ``self.python_versions``.
 
         Args:
             wheel_dir: Directory containing the .whl file and libs/ subdirectory.
-            python_version: Python version (e.g. "3.10") used to pick the
-                manylinux ``cpXY-cpXY`` interpreter that runs auditwheel.
-                When None, the highest version from ``self.python_versions``
-                is used. Auditwheel itself is python-version-agnostic for
-                repairing, but the manylinux image needs *some* installed
-                interpreter to run pip.
         """
         machine = platform.machine().lower()
         arch_map = {
@@ -530,8 +565,7 @@ class XmsConanPackager(object):
         image = f'quay.io/pypa/manylinux_2_28_{arch}'
         abs_wheel_dir = os.path.abspath(wheel_dir)
 
-        if python_version is None:
-            python_version = self._python_versions[-1]
+        python_version = self._highest_python_version(self._python_versions)
         cp_tag = f'cp{python_version.replace(".", "")}'
 
         self.printer.print_message(f'Repairing wheel with auditwheel in {image} (python {python_version})')


### PR DESCRIPTION
## Summary

Tightens `_resolve_python_versions` typing/validation, replaces the order-dependent `self._python_versions[-1]` with an explicit highest-version pick in `generate_configurations` and `repair_linux_wheel`, drops the unused `python_version` param from `repair_linux_wheel`, hardens `__del__` against constructor failures, and corrects the local-fan-out claim in `docs/USAGE.md` §8. Adds tests for `package_id` dropping `python_version` on non-pybind builds, `python_version` propagation via `configure()` into `xms_dependencies`, and the new validation paths.

Closes #47.

## Test plan

- [x] \`uv run --extra test pytest\` — 441 passed, 4 skipped.