### PR TITLE
Fix Windows cxxtestgen path passed to Python (issue #50)

### DIFF
--- a/xmsconan/generator_tools/templates/CMakeLists.txt.jinja
+++ b/xmsconan/generator_tools/templates/CMakeLists.txt.jinja
@@ -212,11 +212,10 @@ if (BUILD_TESTING)
         list(GET cxxtest_INCLUDE_DIRS 0 _xmsconan_cxxtest_include_dir)
         get_filename_component(_xmsconan_cxxtest_root
             "${_xmsconan_cxxtest_include_dir}" DIRECTORY)
-        if (WIN32)
-            set(_xmsconan_cxxtestgen_path "${_xmsconan_cxxtest_root}/bin/cxxtestgen.bat")
-        else ()
-            set(_xmsconan_cxxtestgen_path "${_xmsconan_cxxtest_root}/bin/cxxtestgen")
-        endif ()
+        # Always use bin/cxxtestgen (the Python script). FindCxxTest invokes
+        # ${CXXTEST_TESTGEN_INTERPRETER} (default: python) on this path, so
+        # passing the .bat wrapper makes Python try to parse `@echo off`.
+        set(_xmsconan_cxxtestgen_path "${_xmsconan_cxxtest_root}/bin/cxxtestgen")
         if (NOT EXISTS "${_xmsconan_cxxtestgen_path}")
             message(FATAL_ERROR
                 "Could not locate cxxtestgen at ${_xmsconan_cxxtestgen_path}")


### PR DESCRIPTION
## Summary

- Drop the WIN32 branch in the generated `CMakeLists.txt` that set `CXXTEST_PYTHON_TESTGEN_EXECUTABLE` to `bin/cxxtestgen.bat`.
- `FindCxxTest.cmake` invokes that path with `python`, so the `.bat` wrapper made Python try to parse `@echo off` and broke every Windows CI run.
- The `bin/cxxtestgen` Python script works on every platform, so it is now used unconditionally.

Fixes #50.

## Test plan
- [x] `pytest tests/` (441 passed, 4 skipped)
- [ ] Re-run a downstream Windows CI build (e.g. xmscore) after regenerating its `CMakeLists.txt`