### PR TITLE
Disable boost.locale to unblock boost/1.86.0 build with b2 5.x

### DIFF
--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -322,6 +322,8 @@ def test_create_build_profile_not_confused_by_new_combination_keys(tmp_path):
         '&:wchar_t=builtin\n'
         '&:pybind=False\n'
         '&:testing=False\n'
+        'boost/*:without_stacktrace=True\n'
+        'boost/*:without_locale=True\n'
         '\n'
         '[buildenv]\n'
         'XMS_VERSION=None\n'
@@ -389,7 +391,7 @@ def test_create_build_profile_puts_wildcards_first(tmp_path):
 
 @patch_env(clear=True)
 def test_create_build_profile_with_no_profile_options(tmp_path):
-    """No pkg/*: lines are emitted when profile_options is absent or empty."""
+    """Only the built-in boost defaults are emitted when no caller-supplied profile_options exist."""
     p = XmsConanPackager("xmscore")
     p.generate_configurations(system_platform="linux")
 
@@ -398,10 +400,14 @@ def test_create_build_profile_with_no_profile_options(tmp_path):
     profile_path = p.create_build_profile(config)
     with open(profile_path, "r") as f:
         content = f.read()
-    # Versions aren't supported, so checking for `pkg/1.0:` isn't necessary.
-    # We'll just check for the `/*:` part of `pkg/*:`.
-    for line in content.splitlines():
-        assert "/*:" not in line, f"unexpected dep-qualified line: {line!r}"
+    # The packager unconditionally injects boost defaults (without_stacktrace,
+    # without_locale).  Any other `pkg/*:` line would indicate a stray
+    # caller-supplied option leaking through.
+    dep_lines = [line for line in content.splitlines() if "/*:" in line]
+    assert dep_lines == [
+        "boost/*:without_stacktrace=True",
+        "boost/*:without_locale=True",
+    ]
 
 
 # --- print_configuration_table ---

--- a/xmsconan/package_tools/packager.py
+++ b/xmsconan/package_tools/packager.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Optional
+from typing import Any, Optional
 
 from xmsconan.package_tools.printer import Printer
 
@@ -104,6 +104,17 @@ class XmsConanPackager(object):
         self.printer = Printer()
         self._temp_dir = tempfile.TemporaryDirectory()
         self._temp_dir_path = self._temp_dir.name
+
+        # Disable boost stacktrace to avoid __cxa_allocate_exception symbol
+        # conflict with -static-libstdc++ in pybind shared modules.
+        self._set_default_option_value('boost', 'without_stacktrace', True)
+
+        # Disable boost.locale: boost/1.86.0 passes
+        # `boost.locale.iconv.lib=libiconv` to b2 unconditionally on macOS,
+        # but b2 >=5.2 validates command-line features before loading the
+        # locale Jamfile and rejects it as unknown. No xms library uses
+        # boost.locale, so dropping it is the cleanest unblock.
+        self._set_default_option_value('boost', 'without_locale', True)
 
     def __del__(self):
         """Cleanup the temporary directory."""
@@ -669,6 +680,22 @@ class XmsConanPackager(object):
         print('\n')
         for line in table:
             print(line)
+
+    def _set_default_option_value(self, package: str, option: str, value: Any):
+        """
+        Set an option's value if not already set.
+
+        Args:
+            package: Name of the package to assign a default to.
+            option: Name of the option to assign a default to.
+            value: Default value to assign.
+        """
+        self._profile_options.setdefault(package, {})
+        if option in self._profile_options[package]:
+            # TODO: Make some sort of warning visible
+            return
+
+        self._profile_options[package][option] = value
 
 
 def _profile_order(packages: dict):

--- a/xmsconan/xms_conan2_file.py
+++ b/xmsconan/xms_conan2_file.py
@@ -77,12 +77,6 @@ class XmsConan2File(ConanFile):
 
     def configure(self):
         """The configure method."""
-        # self.version = envvars.get('XMS_VERSION', '99.99.99')
-
-        # Disable boost stacktrace to avoid __cxa_allocate_exception symbol
-        # conflict with -static-libstdc++ in pybind shared modules.
-        self.options["boost"].without_stacktrace = True
-
         # Raise ConanExceptions for Unsupported Versions
         s_os = self.settings.os
         s_compiler = self.settings.compiler


### PR DESCRIPTION
boost/1.86.0 unconditionally appends `boost.locale.iconv.lib=libiconv` to the b2 command line on macOS, but b2 >=5.2 (the version range the boost recipe pins) validates command-line features before loading the boost.locale Jamfile that defines this feature. b2 rejects it as unknown and the build aborts.

No xms library imports boost/locale, so disabling it is the cleanest unblock and follows the same pattern as the existing without_stacktrace = True opt-out.