### PR TITLE
Strip package id for recipe-scoped conan cache path lookups (#66)

### DIFF
--- a/tests/test_coverage_generator.py
+++ b/tests/test_coverage_generator.py
@@ -9,6 +9,7 @@ import pytest
 
 from xmsconan.coverage_tools.coverage_generator import (
     _append_github_summary,
+    _conan_cache_path,
     _cpp_percent_from_summary,
     _find_coverage_package,
     _py_percent_from_summary,
@@ -357,6 +358,63 @@ class TestResolveCoveragePythonVersion:
         """An empty list in [ci] is treated like the key was missing."""
         toml_data = {"ci": {"python_versions": []}}
         assert _resolve_coverage_python_version(toml_data) == "3.13"
+
+
+class TestConanCachePath:
+    """`conan cache path --folder` reference-shape requirements (issue #66).
+
+    Conan 2 requires:
+      * a package reference (``ref:pid``) for per-package folders (``build``,
+        and the default unnamed package folder),
+      * a *recipe* reference (``ref`` only) for ``source``, ``export``, and
+        ``export_source`` — those folders are shared across all packages
+        built from the same recipe revision so a pid is meaningless and the
+        CLI rejects it with ``'--folder source' requires a recipe reference``.
+
+    The previous helper passed whatever shape the caller supplied straight
+    through, which broke ``run_coverage``'s ``source_folder`` lookup.
+    """
+
+    @patch("xmsconan.coverage_tools.coverage_generator.subprocess.run")
+    def test_strips_pid_for_source_folder(self, mock_run):
+        """``--folder=source`` must receive the recipe ref only (no ``:pid``)."""
+        mock_run.return_value = MagicMock(stdout="/some/source/path\n")
+        _conan_cache_path("xmscore/0.0.0:abc123", "source")
+        cmd = mock_run.call_args[0][0]
+        assert "xmscore/0.0.0" in cmd
+        assert "xmscore/0.0.0:abc123" not in cmd, (
+            "source folder lookup must use the recipe reference, not the "
+            "package reference — conan rejects ref:pid for --folder=source"
+        )
+
+    @patch("xmsconan.coverage_tools.coverage_generator.subprocess.run")
+    def test_strips_pid_for_export_folders(self, mock_run):
+        """``export`` and ``export_source`` are recipe-scoped too."""
+        mock_run.return_value = MagicMock(stdout="/p\n")
+        for folder in ("export", "export_source"):
+            _conan_cache_path("xmscore/0.0.0:abc123", folder)
+            cmd = mock_run.call_args[0][0]
+            assert "xmscore/0.0.0:abc123" not in cmd, (
+                f"--folder={folder} must use the recipe reference"
+            )
+            assert "xmscore/0.0.0" in cmd
+
+    @patch("xmsconan.coverage_tools.coverage_generator.subprocess.run")
+    def test_keeps_pid_for_build_folder(self, mock_run):
+        """``--folder=build`` is per-package; the pid must remain."""
+        mock_run.return_value = MagicMock(stdout="/some/build/path\n")
+        _conan_cache_path("xmscore/0.0.0:abc123", "build")
+        cmd = mock_run.call_args[0][0]
+        assert "xmscore/0.0.0:abc123" in cmd, (
+            "build folder lookup must keep the package id — the build "
+            "folder is per-package"
+        )
+
+    @patch("xmsconan.coverage_tools.coverage_generator.subprocess.run")
+    def test_returns_path_from_stdout(self, mock_run):
+        """The trimmed stdout becomes the returned Path."""
+        mock_run.return_value = MagicMock(stdout="  /trimmed/path  \n")
+        assert _conan_cache_path("xmscore/0.0.0:abc", "build") == Path("/trimmed/path")
 
 
 class TestRunCoverageThresholdGating:

--- a/tests/test_coverage_generator.py
+++ b/tests/test_coverage_generator.py
@@ -411,6 +411,26 @@ class TestConanCachePath:
         )
 
     @patch("xmsconan.coverage_tools.coverage_generator.subprocess.run")
+    def test_strips_pid_but_preserves_recipe_revision(self, mock_run):
+        """Recipe revision (``#<hex>``) must survive the strip.
+
+        Conan 2 references look like
+        ``xmscore/0.0.0#<recipe_rev>:<package_id>``. Splitting on the
+        first ``:`` keeps the recipe revision intact — which is what
+        ``conan cache path --folder=source`` actually needs to resolve
+        the source folder of *that revision* (not just the latest
+        recipe). Guards against a future "strip everything after ``#``
+        too" refactor.
+        """
+        mock_run.return_value = MagicMock(stdout="/some/source/path\n")
+        _conan_cache_path("xmscore/0.0.0#deadbeef:abc123", "source")
+        cmd = mock_run.call_args[0][0]
+        assert "xmscore/0.0.0#deadbeef" in cmd
+        assert "abc123" not in " ".join(cmd), (
+            "pid must be stripped, but the recipe revision (after #) must remain"
+        )
+
+    @patch("xmsconan.coverage_tools.coverage_generator.subprocess.run")
     def test_returns_path_from_stdout(self, mock_run):
         """The trimmed stdout becomes the returned Path."""
         mock_run.return_value = MagicMock(stdout="  /trimmed/path  \n")

--- a/xmsconan/coverage_tools/coverage_generator.py
+++ b/xmsconan/coverage_tools/coverage_generator.py
@@ -160,10 +160,29 @@ def _find_coverage_package(library_name: str, python_version: str) -> tuple[str,
     return exact_ref, pid
 
 
+# Folders that conan 2's `cache path` requires a recipe reference (no
+# `:pid`) for — source, export, and export_source are shared across every
+# package built from the same recipe revision, so a package id is
+# meaningless there and conan rejects ref:pid with
+# ``'--folder source' requires a recipe reference`` (see issue #66).
+_RECIPE_SCOPED_FOLDERS = frozenset({"source", "export", "export_source"})
+
+
 def _conan_cache_path(ref_with_pid: str, folder: str) -> Path:
-    """Resolve `conan cache path <ref>:<pid> --folder=<folder>`."""
+    """Resolve ``conan cache path <ref-or-ref:pid> --folder=<folder>``.
+
+    Conan 2 requires a recipe reference (no package id) for ``source``,
+    ``export``, and ``export_source`` folders, and a package reference
+    (with ``:pid``) for ``build`` and the default package folder. Callers
+    can pass either shape — this strips the pid when the folder is
+    recipe-scoped so the same helper works for both kinds of lookup.
+    """
+    if folder in _RECIPE_SCOPED_FOLDERS:
+        ref = ref_with_pid.split(":", 1)[0]
+    else:
+        ref = ref_with_pid
     result = subprocess.run(
-        ["conan", "cache", "path", ref_with_pid, f"--folder={folder}"],
+        ["conan", "cache", "path", ref, f"--folder={folder}"],
         capture_output=True, text=True, check=True,
     )
     return Path(result.stdout.strip())


### PR DESCRIPTION
Closes #66

## Summary

`_conan_cache_path` was passing whatever ref shape the caller supplied straight through to `conan cache path --folder=<folder>`. That worked for `--folder=build` (which wants a package reference `ref:pid`) but broke `--folder=source` — conan 2 requires a *recipe* reference for `source`, `export`, and `export_source` because those folders are shared across all packages built from the same recipe revision, and rejects `ref:pid` with ``'--folder source' requires a recipe reference``.

This is the third failure mode `xmsconan_coverage` hit while wiring up xmscore: after 2.14.1 got the cache lookup to find a package, this call site then died at the source-folder resolution.

## Fix

Introduce `_RECIPE_SCOPED_FOLDERS = {"source", "export", "export_source"}` and strip the `:pid` suffix when the folder is recipe-scoped. Callers can keep passing the same `ref:pid` shape for every lookup — the helper does the right thing for each folder kind. Defense-in-depth so a future caller can't make the same mistake.

## Test plan

- [x] `python -m pytest` — **502 passed, 1 skipped** (up from 498; 4 new tests)
- [x] `python -m flake8` on touched files — clean
- [x] New `TestConanCachePath` class:
  - `test_strips_pid_for_source_folder` — pins the issue #66 fix at the call boundary
  - `test_strips_pid_for_export_folders` — covers the other two recipe-scoped folders
  - `test_keeps_pid_for_build_folder` — guards against an over-eager strip that would break build folder lookup
  - `test_returns_path_from_stdout` — pins the existing return contract

## Docs

No user-facing surface changed — pure internal helper bug fix. No `build.toml` keys, console scripts, env vars, or recipe attributes touched.