### PR TITLE
Propagate XMS_COVERAGE into the conan buildenv (#69)

### DIFF
--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -173,6 +173,49 @@ def test_explicit_coverage_false_overrides_env():
 
 
 @patch_env(clear=True)
+def test_coverage_true_propagates_xms_coverage_into_buildenv():
+    """coverage=True must export XMS_COVERAGE into the profile's [buildenv].
+
+    Without it the activation script never sets ``XMS_COVERAGE`` for the
+    CMake child process, so ``CMakeLists.txt.jinja``'s
+    ``if (DEFINED ENV{XMS_COVERAGE})`` guard is false, ``--coverage`` is
+    never added to the compile flags, no ``.gcno``/``.gcda`` files are
+    produced, and gcovr reports 0% with "All coverage data is filtered
+    out" (issue #69 — the 2.14.0/2.14.1/2.14.2 chain finally got the
+    pipeline to a green run, but the C++ report was empty for exactly
+    this reason).
+    """
+    p = XmsConanPackager("xmscore", coverage=True)
+    p.generate_configurations(system_platform="linux")
+
+    for cfg in p.configurations:
+        assert cfg["buildenv"].get("XMS_COVERAGE") == "1", (
+            f"every configuration must export XMS_COVERAGE=1 in buildenv "
+            f"when coverage=True; missing on {cfg.get('build_type')!r} / "
+            f"options={cfg.get('options')}"
+        )
+
+
+@patch_env(clear=True)
+def test_coverage_false_omits_xms_coverage_from_buildenv():
+    """coverage=False must not leak XMS_COVERAGE into the build profile.
+
+    A non-coverage run reusing the same packager invocation must not
+    pull instrumentation flags into the released binary — that would
+    bloat object size, defeat optimization, and (more importantly)
+    cause ``--coverage`` to be linked into the production wheel.
+    """
+    p = XmsConanPackager("xmscore", coverage=False)
+    p.generate_configurations(system_platform="linux")
+
+    for cfg in p.configurations:
+        assert "XMS_COVERAGE" not in cfg["buildenv"], (
+            f"coverage=False must not export XMS_COVERAGE; leaked on "
+            f"{cfg.get('build_type')!r} / options={cfg.get('options')}"
+        )
+
+
+@patch_env(clear=True)
 def test_testing_variants_added_for_all():
     """Every base config gets a testing variant."""
     p = XmsConanPackager("xmscore")

--- a/xmsconan/package_tools/packager.py
+++ b/xmsconan/package_tools/packager.py
@@ -251,6 +251,17 @@ class XmsConanPackager(object):
             if self._artifacts_dir:
                 combination['buildenv']['XMS_TEST_ARTIFACTS_DIR'] = self._artifacts_dir
 
+            # XMS_COVERAGE has to ride into the profile's [buildenv] so the
+            # conan activation script exports it for the CMake child process.
+            # Without this, the recipe's Python-side `configure()` still sees
+            # XMS_COVERAGE (it inherits the parent env), but CMake's
+            # `if (DEFINED ENV{XMS_COVERAGE})` guard runs in an activated
+            # buildenv subshell that only sees [buildenv] vars — so
+            # `--coverage` is never added, no .gcno files are produced, and
+            # gcovr reports 0% (see issue #69).
+            if self._coverage:
+                combination['buildenv']['XMS_COVERAGE'] = '1'
+
             # Set macOS deployment target for consistent wheel builds
             if combination.get('os') == 'Macos':
                 combination['buildenv']['MACOSX_DEPLOYMENT_TARGET'] = '15.0'


### PR DESCRIPTION
Closes #69

## Summary

After 2.14.0 → 2.14.2 fixed the discovery, filter, fan-out, and cache-path bugs, `xmsconan_coverage` finally got a green end-to-end run against xmscore — and the C++ coverage report came back **0% with no files measured**, because the binary was built without instrumentation. Fifth bug in the coverage rollout, surfaced only after each of the prior four had been individually fixed.

## Root cause

`coverage_generator.py` sets `XMS_COVERAGE=1` in the parent process env. The recipe's Python-side `configure()` and `run_python_tests` correctly observe it (same conan process). But CMake is a **child** process that conan runs under the profile's `[buildenv]` activation. `XmsConanPackager.generate_configurations` wasn't adding `XMS_COVERAGE` to the buildenv dict, so the activation script never exported it, so `CMakeLists.txt.jinja`'s `if (DEFINED ENV{XMS_COVERAGE})` guard evaluated false, so `add_compile_options(--coverage -O0 -g)` was never executed. The compile succeeded with no instrumentation, no `.gcno`/`.gcda` files were produced, and gcovr's report came back `0/0 --%` with "All coverage data is filtered out".

Direct log evidence (xmscore Coverage workflow attempt #3 against 2.14.2):

- CMake configure command: `cmake -G "Unix Makefiles" -D... -DCMAKE_BUILD_TYPE="Debug" -DIS_PYTHON_BUILD="True" -DXMS_VERSION="0.0.0" ...` — no `-DXMS_COVERAGE`, and the env activation never exported it.
- Real compilation ran (`[3%] Building CXX object .../daStreamIo.cpp.o` etc.) but without `--coverage`.
- gcovr: `(WARNING) All coverage data is filtered out. Please check your paths and filters.` → `TOTAL 0 0 --%`.

## Fix

One-line addition to `xmsconan/package_tools/packager.py:generate_configurations`, gated on the existing `self._coverage` flag:

```python
if self._coverage:
    combination['buildenv']['XMS_COVERAGE'] = '1'
```

Same gate that already controls whether `Debug+pybind` is emitted, so the propagation is consistent with the rest of the coverage-aware behavior.

## Test plan

- [x] `python -m pytest` — **505 passed, 1 skipped** (up from 503; 2 new)
- [x] `python -m flake8` on touched files — clean
- [x] New tests:
  - `test_coverage_true_propagates_xms_coverage_into_buildenv` — pins that every configuration's buildenv exports `XMS_COVERAGE=1` when `coverage=True`
  - `test_coverage_false_omits_xms_coverage_from_buildenv` — pins that non-coverage runs never leak the flag, so production wheels can't accidentally end up with `--coverage` linked in

## Docs

No user-facing surface changed — internal `[buildenv]` plumbing.

## Out of scope

Python coverage on the same xmscore run also reports 0% — a different shape (recipe correctly invokes `pytest-cov --cov=xms.<dir>` and tests pass, but pytest-cov measures 0 files). Likely related to xmscore's `xms/` Python package layout vs. the wheel install path, not an xmsconan env-propagation issue. Will dig into it separately once this C++ fix is in.