### PR TITLE
rglob for pytest-cov artifacts under build folder (#71)

### DIFF
--- a/tests/test_coverage_generator.py
+++ b/tests/test_coverage_generator.py
@@ -9,12 +9,15 @@ import pytest
 
 from xmsconan.coverage_tools.coverage_generator import (
     _append_github_summary,
+    _assert_gcovr_collected_data,
     _conan_cache_path,
     _cpp_percent_from_summary,
     _find_coverage_package,
     _find_pytest_cov_artifact,
+    _is_simple_relative_filter_pattern,
     _py_percent_from_summary,
     _resolve_coverage_python_version,
+    _resolve_gcovr_filters,
     run_coverage,
 )
 from xmsconan.generator_tools.ci_file_generator import _coverage_context
@@ -555,6 +558,164 @@ class TestFindPytestCovArtifact:
         """An invalid ``kind`` is a programming error, not a silent fall-through."""
         with pytest.raises(ValueError, match="kind"):
             _find_pytest_cov_artifact(tmp_path, "cov-py.xml", kind="bogus")
+
+
+class TestResolveGcovrFilters:
+    """Filter resolution emits both relative and absolute-anchored forms (PR #72 review).
+
+    Without this, the default ``[coverage].filters = ["<library_name>/"]``
+    relies entirely on gcovr's internal path-normalization behavior to
+    decide whether ``xmscore/`` matches the absolute paths embedded in
+    the freshly-instrumented ``.gcno`` files. Subtle, version-specific,
+    silent on failure. Emitting a redundant absolute-path-anchored form
+    can only widen matches (gcovr ORs ``--filter`` entries) so the
+    duplication is purely additive defense.
+    """
+
+    def test_simple_relative_filter_emits_both_forms(self):
+        """A bare path segment gets both its original AND an anchored copy."""
+        source_folder = Path("/conan/p/xmsXXX/s")
+        out = _resolve_gcovr_filters(["xmscore/"], source_folder)
+        assert "xmscore/" in out
+        # Anchored form: re.escape of source_folder + "/" + the original
+        # Dots in the source folder must be escaped so they're literal.
+        assert any(
+            "/conan/p/xmsXXX/s/xmscore/" in entry
+            for entry in out
+            if entry != "xmscore/"
+        ), f"expected an absolute-anchored copy in {out}"
+        # Exactly two entries (one original, one anchored):
+        assert len(out) == 2
+
+    def test_anchored_form_escapes_dots_in_source_folder(self):
+        """The conan source path contains dots (e.g. ``.conan2``) — they must be escaped.
+
+        Without ``re.escape``, the dots would be regex wildcards and the
+        anchored filter would match *anything* in the same position,
+        defeating the purpose of anchoring.
+        """
+        import re as _re
+        source_folder = Path("/github/home/.conan2/p/xmsXXX/s")
+        out = _resolve_gcovr_filters(["xmscore/"], source_folder)
+        anchored = [e for e in out if e != "xmscore/"][0]
+        # The anchored form must work as a regex against the real absolute path.
+        real_path = "/github/home/.conan2/p/xmsXXX/s/xmscore/math/math.cpp"
+        assert _re.search(anchored, real_path), (
+            f"anchored filter {anchored!r} must match the real absolute path"
+        )
+        # And it must NOT match a near-miss where the dot is a different char,
+        # proving the dot was actually escaped:
+        near_miss = "/github/home/Xconan2/p/xmsXXX/s/xmscore/math/math.cpp"
+        assert not _re.search(anchored, near_miss), (
+            f"anchored filter {anchored!r} must treat dots as literals"
+        )
+
+    def test_regex_pattern_passes_through_unchanged(self):
+        """A pattern with regex metacharacters is the user's deliberate choice."""
+        source_folder = Path("/conan/p/xmsXXX/s")
+        out = _resolve_gcovr_filters([r".*/xmscore/.*\.cpp$"], source_folder)
+        assert out == [r".*/xmscore/.*\.cpp$"], (
+            "regex-looking filters must not be doubled-up — user knows what they want"
+        )
+
+    def test_absolute_pattern_passes_through_unchanged(self):
+        """An already-absolute pattern is treated as the user's deliberate choice."""
+        source_folder = Path("/conan/p/xmsXXX/s")
+        out = _resolve_gcovr_filters(["/some/abs/path/"], source_folder)
+        assert out == ["/some/abs/path/"]
+
+    def test_anchored_pattern_with_caret_passes_through(self):
+        """``^``-anchored patterns are explicit regexes and shouldn't be doubled."""
+        source_folder = Path("/conan/p/xmsXXX/s")
+        out = _resolve_gcovr_filters(["^xmscore/"], source_folder)
+        assert out == ["^xmscore/"]
+
+    def test_empty_filter_list_returns_empty(self):
+        """No filters in, no filters out."""
+        assert _resolve_gcovr_filters([], Path("/anywhere")) == []
+
+    def test_mixed_list_handles_each_independently(self):
+        """A mix of simple-relative and regex patterns: each treated correctly."""
+        source_folder = Path("/conan/p/xmsXXX/s")
+        out = _resolve_gcovr_filters(
+            ["xmscore/", r".*/python/.*"], source_folder,
+        )
+        # The simple-relative gets doubled (2 entries); the regex stays once (1 entry).
+        assert len(out) == 3
+        assert "xmscore/" in out
+        assert r".*/python/.*" in out
+
+
+class TestIsSimpleRelativeFilterPattern:
+    """Classifier for which filter patterns get the anchored-copy treatment."""
+
+    def test_bare_path_segment_is_simple_relative(self):
+        assert _is_simple_relative_filter_pattern("xmscore/")
+        assert _is_simple_relative_filter_pattern("xmscore")
+        assert _is_simple_relative_filter_pattern("subdir/lib/")
+
+    def test_regex_metachars_disqualify(self):
+        assert not _is_simple_relative_filter_pattern(".*xmscore")
+        assert not _is_simple_relative_filter_pattern("xms.*core")
+        assert not _is_simple_relative_filter_pattern(r"xmscore/.*\.cpp$")
+        assert not _is_simple_relative_filter_pattern("xms(core|grid)")
+        assert not _is_simple_relative_filter_pattern("xms?core")
+
+    def test_anchors_disqualify(self):
+        assert not _is_simple_relative_filter_pattern("^xmscore")
+        assert not _is_simple_relative_filter_pattern("/abs/xmscore")
+        assert not _is_simple_relative_filter_pattern("(group)")
+
+    def test_empty_string_is_not_simple_relative(self):
+        assert not _is_simple_relative_filter_pattern("")
+
+
+class TestAssertGcovrCollectedData:
+    """Loud failure when gcovr returns an empty summary (PR #72 review, option B).
+
+    Before this guard, ``line_total == 0`` silently coerced ``cpp_raw``
+    to 0.0 and — with the default ``[coverage].cpp_threshold = 0`` —
+    produced a "PASS" with an empty report. The operator had to scroll
+    the run log for gcovr's `All coverage data is filtered out` line
+    to understand what happened. This guard converts that into a hard
+    failure with a diagnostic naming the three most likely causes.
+    """
+
+    def test_raises_when_line_total_zero(self, tmp_path):
+        """Empty gcovr result → RuntimeError naming the build folder."""
+        summary = tmp_path / "cov-cpp-summary.json"
+        summary.write_text(json.dumps({"line_percent": 0.0, "line_total": 0}))
+        build_folder = tmp_path / "build"
+        with pytest.raises(RuntimeError) as exc_info:
+            _assert_gcovr_collected_data(summary, build_folder, ["xmscore/"])
+        msg = str(exc_info.value)
+        assert str(build_folder) in msg
+        # Diagnostic must name the most likely cause (XMS_COVERAGE / #69):
+        assert "XMS_COVERAGE" in msg or "#69" in msg
+        # And echo the filters we actually used, so the operator can
+        # compare them against the real source paths:
+        assert "xmscore/" in msg
+
+    def test_passes_when_line_total_positive(self, tmp_path):
+        """A real measurement (any non-zero line_total) is not an error.
+
+        Includes the legitimate 0%-but-non-zero-lines case: 1000 lines
+        instrumented, 0 covered by tests. That's a real result, the
+        threshold check handles it, this guard must not interfere.
+        """
+        summary = tmp_path / "cov-cpp-summary.json"
+        summary.write_text(json.dumps({"line_percent": 0.0, "line_total": 1000}))
+        _assert_gcovr_collected_data(summary, tmp_path, ["xmscore/"])
+
+    def test_passes_when_line_total_key_absent(self, tmp_path):
+        """Schema drift (no ``line_total`` at all) is left to the percent extractor.
+
+        ``_cpp_percent_from_summary`` already raises a clear
+        ``ValueError`` on missing keys; this guard doesn't double up.
+        """
+        summary = tmp_path / "cov-cpp-summary.json"
+        summary.write_text(json.dumps({"line_percent": 50.0}))
+        _assert_gcovr_collected_data(summary, tmp_path, ["xmscore/"])
 
 
 class TestRunCoverageThresholdGating:

--- a/tests/test_coverage_generator.py
+++ b/tests/test_coverage_generator.py
@@ -12,6 +12,7 @@ from xmsconan.coverage_tools.coverage_generator import (
     _conan_cache_path,
     _cpp_percent_from_summary,
     _find_coverage_package,
+    _find_pytest_cov_artifact,
     _py_percent_from_summary,
     _resolve_coverage_python_version,
     run_coverage,
@@ -437,6 +438,73 @@ class TestConanCachePath:
         assert _conan_cache_path("xmscore/0.0.0:abc", "build") == Path("/trimmed/path")
 
 
+class TestFindPytestCovArtifact:
+    """Locate pytest-cov outputs anywhere under the conan build folder (issue #71).
+
+    ``conan cache path --folder=build`` returns the conan-managed build root
+    (e.g. ``/.conan2/p/b/xmsXXX/b``), but the recipe's ``run_python_tests``
+    writes the coverage artifacts into a *layout-specific* subdirectory
+    (e.g. ``<root>/build/Debug/``). The previous code looked at the root
+    only and silently fell through the ``if exists()`` guards, defaulting
+    ``py_raw`` to 0.0.
+
+    These tests pin the new ``_find_pytest_cov_artifact`` helper so the
+    tool tolerates whatever depth the recipe chose.
+    """
+
+    def test_finds_artifact_at_root(self, tmp_path):
+        """Artifact directly at build_folder/ is returned."""
+        artifact = tmp_path / "cov-py-summary.json"
+        artifact.write_text("{}", encoding="utf-8")
+        assert _find_pytest_cov_artifact(tmp_path, "cov-py-summary.json") == artifact
+
+    def test_finds_artifact_in_layout_subdir(self, tmp_path):
+        """Artifact at build_folder/build/Debug/ (the xmscore case) is returned."""
+        layout_subdir = tmp_path / "build" / "Debug"
+        layout_subdir.mkdir(parents=True)
+        artifact = layout_subdir / "cov-py-summary.json"
+        artifact.write_text("{}", encoding="utf-8")
+        assert _find_pytest_cov_artifact(tmp_path, "cov-py-summary.json") == artifact
+
+    def test_returns_none_when_absent(self, tmp_path):
+        """No matching file anywhere under build_folder → None (no exception).
+
+        This is the legitimate ``pybind=False`` case where pytest-cov
+        never ran, not an error.
+        """
+        assert _find_pytest_cov_artifact(tmp_path, "cov-py-summary.json") is None
+
+    def test_picks_newest_on_collision_and_warns(self, tmp_path, caplog):
+        """Multiple matches → newest by mtime wins, with a warning logged.
+
+        Multi-build-type folders (e.g. ``Debug`` and ``RelWithDebInfo`` both
+        present, perhaps from a stale cache) can each contain their own
+        pytest-cov artifacts. Pick the most recent and tell the operator,
+        rather than picking silently or raising.
+        """
+        old_dir = tmp_path / "build" / "Debug"
+        new_dir = tmp_path / "build" / "RelWithDebInfo"
+        old_dir.mkdir(parents=True)
+        new_dir.mkdir(parents=True)
+        old = old_dir / "cov-py.xml"
+        new = new_dir / "cov-py.xml"
+        old.write_text("<old/>", encoding="utf-8")
+        new.write_text("<new/>", encoding="utf-8")
+        # Force old to be older than new by a clear margin.
+        old_time = new.stat().st_mtime - 100.0
+        os.utime(old, (old_time, old_time))
+
+        with caplog.at_level("WARNING",
+                             logger="xmsconan.coverage_tools.coverage_generator"):
+            result = _find_pytest_cov_artifact(tmp_path, "cov-py.xml")
+
+        assert result == new
+        assert any("Multiple" in rec.message or "multiple" in rec.message.lower()
+                   for rec in caplog.records), (
+            "a warning naming the collision must be emitted so the operator can fix it"
+        )
+
+
 class TestRunCoverageThresholdGating:
     """End-to-end gating logic with all subprocess calls mocked."""
 
@@ -759,6 +827,77 @@ class TestRunCoverageThresholdGating:
         assert exit_code != 0, "Build failure must surface as non-zero exit"
         assert (tmp_path / "cov-cpp-summary.json").exists(), (
             "gcovr summary must be produced even when the build step failed"
+        )
+
+    @patch("xmsconan.coverage_tools.coverage_generator._find_coverage_package")
+    @patch("xmsconan.coverage_tools.coverage_generator._conan_cache_path")
+    @patch("xmsconan.coverage_tools.coverage_generator.subprocess.run")
+    def test_finds_python_artifacts_in_layout_subdir(
+        self, mock_run, mock_path, mock_find, tmp_path,
+    ):
+        """run_coverage locates pytest-cov outputs under build_folder/build/<type>/.
+
+        Production reality: the recipe's ``run_python_tests`` writes
+        ``cov-py-summary.json`` into ``<conan-build-root>/build/Debug/``,
+        not at the conan-build-root itself. The earlier code looked at the
+        root only, silently fell through ``if exists()``, and defaulted
+        ``py_raw`` to 0.0 (issue #71). This test pins the layout-subdir
+        path so the regression can't come back.
+        """
+        toml_file = tmp_path / "build.toml"
+        toml_file.write_text(
+            'library_name = "xmscore"\n'
+            'description = "desc"\n'
+            'python_namespaced_dir = "core"\n'
+            '\n'
+            '[coverage]\n'
+            'cpp_threshold = 0\n'
+            'python_threshold = 70\n',
+            encoding="utf-8",
+        )
+        build_folder = tmp_path / "fake-build"
+        source_folder = tmp_path / "fake-source"
+        # Layout-specific subdir, mirroring what the recipe does:
+        layout_subdir = build_folder / "build" / "Debug"
+        layout_subdir.mkdir(parents=True)
+        source_folder.mkdir()
+        # Stage pytest-cov artifacts at the *deep* path:
+        (layout_subdir / "cov-py-summary.json").write_text(
+            json.dumps({"totals": {"percent_covered": 82.5}})
+        )
+        (layout_subdir / "cov-py.xml").write_text("<coverage/>")
+        (layout_subdir / "coverage-html-py").mkdir()
+        (layout_subdir / "coverage-html-py" / "index.html").write_text(
+            "<html>py</html>",
+        )
+
+        def fake_run(cmd, env=None, cwd=None, **_kw):
+            if isinstance(cmd, list) and cmd and cmd[0] == "gcovr":
+                idx = cmd.index("--json-summary")
+                Path(cmd[idx + 1]).write_text(json.dumps({"line_percent": 99.0}))
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_run
+        mock_find.return_value = ("xmscore/0.0.0", "pid")
+        mock_path.side_effect = lambda _ref, kind: (
+            build_folder if kind == "build" else source_folder
+        )
+
+        exit_code = run_coverage(str(toml_file), "0.0.0", str(tmp_path))
+
+        # The summary, the xml, and the html dir must all have been hoisted
+        # up to the workspace root from their deep layout location.
+        assert (tmp_path / "cov-py-summary.json").exists(), (
+            "run_coverage must find cov-py-summary.json under build_folder/build/Debug/"
+        )
+        assert (tmp_path / "cov-py.xml").exists()
+        assert (tmp_path / "coverage-html-py" / "index.html").exists()
+        # And the percentage must reflect the real 82.5% from the staged file,
+        # not the silent 0.0 default that came back when the tool looked at
+        # the wrong depth.
+        assert exit_code == 0, (
+            "82.5% must satisfy the 70.0 python_threshold — getting non-zero "
+            "exit means the artifact wasn't found and py_raw fell back to 0.0"
         )
 
 

--- a/tests/test_coverage_generator.py
+++ b/tests/test_coverage_generator.py
@@ -650,11 +650,13 @@ class TestIsSimpleRelativeFilterPattern:
     """Classifier for which filter patterns get the anchored-copy treatment."""
 
     def test_bare_path_segment_is_simple_relative(self):
+        """Plain path segments — the default-filter shape — count as simple relative."""
         assert _is_simple_relative_filter_pattern("xmscore/")
         assert _is_simple_relative_filter_pattern("xmscore")
         assert _is_simple_relative_filter_pattern("subdir/lib/")
 
     def test_regex_metachars_disqualify(self):
+        """Any regex metacharacter signals a user-authored regex — leave it alone."""
         assert not _is_simple_relative_filter_pattern(".*xmscore")
         assert not _is_simple_relative_filter_pattern("xms.*core")
         assert not _is_simple_relative_filter_pattern(r"xmscore/.*\.cpp$")
@@ -662,11 +664,13 @@ class TestIsSimpleRelativeFilterPattern:
         assert not _is_simple_relative_filter_pattern("xms?core")
 
     def test_anchors_disqualify(self):
+        """Leading ``^`` / ``/`` / ``(`` are explicit anchors — already user-controlled."""
         assert not _is_simple_relative_filter_pattern("^xmscore")
         assert not _is_simple_relative_filter_pattern("/abs/xmscore")
         assert not _is_simple_relative_filter_pattern("(group)")
 
     def test_empty_string_is_not_simple_relative(self):
+        """An empty pattern is never simple-relative — nothing to anchor."""
         assert not _is_simple_relative_filter_pattern("")
 
 

--- a/tests/test_coverage_generator.py
+++ b/tests/test_coverage_generator.py
@@ -504,6 +504,58 @@ class TestFindPytestCovArtifact:
             "a warning naming the collision must be emitted so the operator can fix it"
         )
 
+    def test_kind_dir_filters_out_stale_file_with_same_name(self, tmp_path):
+        """A real directory must win over a same-named stale file (PR #72 review).
+
+        The exact scenario the reviewer flagged: a stale leftover *file*
+        named ``coverage-html-py`` sitting next to (or anywhere near) the
+        real ``coverage-html-py/`` directory. Without ``kind="dir"``,
+        ``rglob`` returns both, mtime sort can pick the file, the call
+        site's ``is_dir()`` is False, the HTML report is silently
+        skipped, and the operator sees no diagnostic. With ``kind="dir"``
+        the stale file is filtered out at the helper level and the real
+        directory always wins.
+        """
+        real_dir = tmp_path / "build" / "Debug" / "coverage-html-py"
+        real_dir.mkdir(parents=True)
+        (real_dir / "index.html").write_text("<html/>", encoding="utf-8")
+        stale_file = tmp_path / "cache" / "coverage-html-py"
+        stale_file.parent.mkdir(parents=True)
+        stale_file.write_text("stale", encoding="utf-8")
+        # Make the stale file the newer one — exactly the failure mode
+        # described in the review.
+        new_time = real_dir.stat().st_mtime + 100.0
+        os.utime(stale_file, (new_time, new_time))
+
+        result = _find_pytest_cov_artifact(tmp_path, "coverage-html-py", kind="dir")
+        assert result == real_dir
+        assert result.is_dir()
+
+    def test_kind_file_filters_out_directories_with_same_name(self, tmp_path):
+        """Symmetric guard: a directory must not shadow a same-named real file.
+
+        Less likely than the dir-vs-file failure mode but still possible
+        if someone manually created an empty directory whose name
+        collides with a pytest-cov artifact. ``kind="file"`` keeps the
+        helper symmetric.
+        """
+        real_file = tmp_path / "build" / "Debug" / "cov-py.xml"
+        real_file.parent.mkdir(parents=True)
+        real_file.write_text("<coverage/>", encoding="utf-8")
+        stale_dir = tmp_path / "cov-py.xml"
+        stale_dir.mkdir()
+        new_time = real_file.stat().st_mtime + 100.0
+        os.utime(stale_dir, (new_time, new_time))
+
+        result = _find_pytest_cov_artifact(tmp_path, "cov-py.xml", kind="file")
+        assert result == real_file
+        assert result.is_file()
+
+    def test_kind_invalid_value_raises(self, tmp_path):
+        """An invalid ``kind`` is a programming error, not a silent fall-through."""
+        with pytest.raises(ValueError, match="kind"):
+            _find_pytest_cov_artifact(tmp_path, "cov-py.xml", kind="bogus")
+
 
 class TestRunCoverageThresholdGating:
     """End-to-end gating logic with all subprocess calls mocked."""

--- a/xmsconan/coverage_tools/coverage_generator.py
+++ b/xmsconan/coverage_tools/coverage_generator.py
@@ -168,6 +168,35 @@ def _find_coverage_package(library_name: str, python_version: str) -> tuple[str,
 _RECIPE_SCOPED_FOLDERS = frozenset({"source", "export", "export_source"})
 
 
+def _find_pytest_cov_artifact(build_folder: Path, name: str):
+    """Locate a pytest-cov artifact (file or directory) inside the conan build folder.
+
+    The recipe's ``run_python_tests`` writes coverage artifacts into a
+    layout-specific subdirectory (e.g. ``<build_folder>/build/Debug/``),
+    not the conan-managed build root that ``conan cache path
+    --folder=build`` returns. Walking with ``rglob`` is robust against
+    recipe layout changes and multi-build-type folders (see issue #71).
+
+    Returns the matching path. ``None`` if the artifact isn't present
+    (legitimate when pytest-cov never ran — e.g., ``pybind=False``).
+
+    When more than one match exists (e.g. stale leftover from a prior
+    build type) the newest by ``st_mtime`` is returned and a warning is
+    logged so the operator can clean up.
+    """
+    matches = sorted(build_folder.rglob(name))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        LOGGER.warning(
+            "Multiple %s entries under %s; using newest by mtime: %s. All candidates: %s",
+            name, build_folder, matches[0],
+            [str(m) for m in matches],
+        )
+    return matches[0]
+
+
 def _conan_cache_path(ref_with_pid: str, folder: str) -> Path:
     """Resolve ``conan cache path <ref-or-ref:pid> --folder=<folder>``.
 
@@ -347,17 +376,20 @@ def run_coverage(toml_file_path: str, version: str, output_dir: str) -> int:
     cpp_summary = _run_gcovr(source_folder, build_folder, coverage_cfg, output_dir)
 
     # 5. Locate Python coverage artifacts produced inside the build folder by
-    #    run_python_tests, and copy the JSON summary up to the workspace root.
-    py_summary_src = build_folder / "cov-py-summary.json"
+    #    run_python_tests, and copy them up to the workspace root. The recipe
+    #    writes them into a layout-specific subdirectory (e.g.
+    #    ``<build_folder>/build/Debug/``), not the conan-managed build root,
+    #    so we walk to find them regardless of depth (see issue #71).
     py_summary = output_dir / "cov-py-summary.json"
-    if py_summary_src.exists():
+    py_summary_src = _find_pytest_cov_artifact(build_folder, "cov-py-summary.json")
+    if py_summary_src is not None:
         shutil.copy2(py_summary_src, py_summary)
-    py_xml_src = build_folder / "cov-py.xml"
-    if py_xml_src.exists():
+    py_xml_src = _find_pytest_cov_artifact(build_folder, "cov-py.xml")
+    if py_xml_src is not None:
         shutil.copy2(py_xml_src, output_dir / "cov-py.xml")
-    py_html_src = build_folder / "coverage-html-py"
+    py_html_src = _find_pytest_cov_artifact(build_folder, "coverage-html-py")
     py_html_dst = output_dir / "coverage-html-py"
-    if py_html_src.is_dir():
+    if py_html_src is not None and py_html_src.is_dir():
         if py_html_dst.exists():
             shutil.rmtree(py_html_dst)
         shutil.copytree(py_html_src, py_html_dst)

--- a/xmsconan/coverage_tools/coverage_generator.py
+++ b/xmsconan/coverage_tools/coverage_generator.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 import sys
 import traceback
+from typing import Optional
 
 # 2. Third party modules
 try:
@@ -168,7 +169,7 @@ def _find_coverage_package(library_name: str, python_version: str) -> tuple[str,
 _RECIPE_SCOPED_FOLDERS = frozenset({"source", "export", "export_source"})
 
 
-def _find_pytest_cov_artifact(build_folder: Path, name: str):
+def _find_pytest_cov_artifact(build_folder: Path, name: str, kind: Optional[str] = None):
     """Locate a pytest-cov artifact (file or directory) inside the conan build folder.
 
     The recipe's ``run_python_tests`` writes coverage artifacts into a
@@ -177,6 +178,14 @@ def _find_pytest_cov_artifact(build_folder: Path, name: str):
     --folder=build`` returns. Walking with ``rglob`` is robust against
     recipe layout changes and multi-build-type folders (see issue #71).
 
+    ``kind`` filters matches by filesystem type — ``"file"`` keeps only
+    regular files, ``"dir"`` keeps only directories, ``None`` (the
+    default) keeps both. This guards against a real
+    ``coverage-html-py/`` directory being shadowed by a same-named
+    stale *file* (which would silently fall through the call-site
+    ``is_dir()`` check), and vice versa. Without ``kind``, the helper
+    behaves exactly as a name-based ``rglob`` does.
+
     Returns the matching path. ``None`` if the artifact isn't present
     (legitimate when pytest-cov never ran — e.g., ``pybind=False``).
 
@@ -184,9 +193,18 @@ def _find_pytest_cov_artifact(build_folder: Path, name: str):
     build type) the newest by ``st_mtime`` is returned and a warning is
     logged so the operator can clean up.
     """
-    matches = sorted(build_folder.rglob(name))
+    matches = list(build_folder.rglob(name))
+    if kind == "file":
+        matches = [m for m in matches if m.is_file()]
+    elif kind == "dir":
+        matches = [m for m in matches if m.is_dir()]
+    elif kind is not None:
+        raise ValueError(
+            f"kind must be 'file', 'dir', or None; got {kind!r}"
+        )
     if not matches:
         return None
+    matches.sort()
     if len(matches) > 1:
         matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
         LOGGER.warning(
@@ -381,15 +399,21 @@ def run_coverage(toml_file_path: str, version: str, output_dir: str) -> int:
     #    ``<build_folder>/build/Debug/``), not the conan-managed build root,
     #    so we walk to find them regardless of depth (see issue #71).
     py_summary = output_dir / "cov-py-summary.json"
-    py_summary_src = _find_pytest_cov_artifact(build_folder, "cov-py-summary.json")
+    py_summary_src = _find_pytest_cov_artifact(
+        build_folder, "cov-py-summary.json", kind="file",
+    )
     if py_summary_src is not None:
         shutil.copy2(py_summary_src, py_summary)
-    py_xml_src = _find_pytest_cov_artifact(build_folder, "cov-py.xml")
+    py_xml_src = _find_pytest_cov_artifact(build_folder, "cov-py.xml", kind="file")
     if py_xml_src is not None:
         shutil.copy2(py_xml_src, output_dir / "cov-py.xml")
-    py_html_src = _find_pytest_cov_artifact(build_folder, "coverage-html-py")
+    # ``kind="dir"`` guards against a stale same-named *file* shadowing
+    # the real ``coverage-html-py/`` directory in mtime-collision order.
+    py_html_src = _find_pytest_cov_artifact(
+        build_folder, "coverage-html-py", kind="dir",
+    )
     py_html_dst = output_dir / "coverage-html-py"
-    if py_html_src is not None and py_html_src.is_dir():
+    if py_html_src is not None:
         if py_html_dst.exists():
             shutil.rmtree(py_html_dst)
         shutil.copytree(py_html_src, py_html_dst)

--- a/xmsconan/coverage_tools/coverage_generator.py
+++ b/xmsconan/coverage_tools/coverage_generator.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -235,6 +236,110 @@ def _conan_cache_path(ref_with_pid: str, folder: str) -> Path:
     return Path(result.stdout.strip())
 
 
+_REGEX_METACHARS = frozenset(r".*+?[]{}|\\$")
+
+
+def _is_simple_relative_filter_pattern(pattern: str) -> bool:
+    """True if ``pattern`` looks like a bare relative path segment.
+
+    The default ``[coverage].filters`` value is ``"<library_name>/"`` — a
+    plain path segment. Such patterns get re-emitted with an absolute-
+    path-anchored copy by ``_resolve_gcovr_filters`` so gcovr can match
+    them regardless of whether it normalizes paths to relative-to-root
+    or compares against absolute paths internally.
+
+    A pattern is considered "simple relative" when it has no leading
+    anchor (``/``, ``^``, ``(``) and no regex metacharacters. Users who
+    write real regexes get their patterns through unchanged.
+    """
+    if not pattern:
+        return False
+    if pattern.startswith(("/", "^", "(")):
+        return False
+    if any(c in pattern for c in _REGEX_METACHARS):
+        return False
+    return True
+
+
+def _resolve_gcovr_filters(filters, source_folder: Path):
+    """Build the list of ``--filter`` values to pass to gcovr.
+
+    For each entry in ``filters`` that looks like a simple relative
+    path segment (per ``_is_simple_relative_filter_pattern``), this
+    function emits *two* entries: the original (which matches against
+    relative-to-root paths, gcovr's default normalization), AND an
+    absolute-path-anchored form (``re.escape(source_folder) + "/" +
+    pattern``) which matches the absolute paths embedded in ``.gcno``
+    files if gcovr ever falls back to absolute matching.
+
+    Multiple ``--filter`` entries are OR'd by gcovr (a file is kept if
+    any filter matches), so emitting both forms is purely additive — it
+    can only widen matches, never narrow them — and guards against
+    subtle differences in how gcovr resolves source paths across
+    versions. Regex-looking patterns and patterns that already start
+    with an anchor pass through unchanged.
+    """
+    # ``as_posix()`` so the anchored form uses forward slashes regardless
+    # of the host OS — coverage runs in a Linux container, and the
+    # ``.gcno`` source paths there are forward-slash even when the
+    # helper executes on a Windows dev machine.
+    result = []
+    abs_root = source_folder.as_posix().rstrip("/")
+    for pattern in filters:
+        result.append(pattern)
+        if _is_simple_relative_filter_pattern(pattern):
+            result.append(re.escape(abs_root) + "/" + pattern)
+    return result
+
+
+def _assert_gcovr_collected_data(summary_path: Path, build_folder: Path,
+                                 filter_args) -> None:
+    """Raise if gcovr's summary reports zero instrumented lines.
+
+    ``line_total == 0`` means gcovr ran successfully but produced an
+    empty report. Three common causes, in descending likelihood:
+
+      1. The binary was compiled without ``--coverage``. ``XMS_COVERAGE``
+         needs to be propagated to CMake (see #69); if the recipe
+         skipped the ``add_compile_options(--coverage -O0 -g)`` block,
+         no ``.gcno`` files exist for gcovr to read.
+      2. ``[coverage].filters`` / ``[coverage].excludes`` filtered out
+         every source file. The defaults are conservative, but a custom
+         filter that doesn't match the absolute paths in the ``.gcno``
+         files would silently exclude everything.
+      3. The build folder is genuinely empty (e.g., the package was
+         pulled from a binary-only cache rather than rebuilt).
+
+    A legitimate 0% (no tests covered any lines) reports
+    ``line_total > 0`` with ``line_percent == 0.0`` — that is NOT
+    raised here; it's a real measurement and the threshold check
+    handles it.
+
+    Schema drift (``line_total`` missing entirely) is tolerated: leave
+    the diagnostic to ``_cpp_percent_from_summary``, which already
+    surfaces missing keys with a clear ``ValueError``.
+    """
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+    line_total = data.get("line_total")
+    if line_total is None or line_total > 0:
+        return
+    raise RuntimeError(
+        "gcovr collected zero instrumented lines from "
+        f"{build_folder}. The C++ coverage report is empty. "
+        "Common causes:\n"
+        "  1. The binary was compiled without --coverage. Verify that "
+        "XMS_COVERAGE=1 reached the CMake configure step (see #69 — "
+        "this is the most common cause).\n"
+        "  2. The filter patterns excluded every source file. Filters "
+        f"passed to gcovr were: {filter_args!r}. Compare these against "
+        "the absolute source paths embedded in the .gcno files under "
+        f"{build_folder}.\n"
+        "  3. No .gcno files exist in the build folder at all (the "
+        "package may have been pulled from a binary cache rather than "
+        "rebuilt with instrumentation)."
+    )
+
+
 def _run_gcovr(source_folder: Path, build_folder: Path, coverage_cfg: dict,
                output_dir: Path) -> Path:
     """Run gcovr against the build folder. Returns path to JSON summary."""
@@ -254,12 +359,16 @@ def _run_gcovr(source_folder: Path, build_folder: Path, coverage_cfg: dict,
         "--gcov-ignore-errors=no_working_dir_found",
         "--gcov-ignore-errors=source_not_found",
     ]
-    for f in coverage_cfg.get("filters", []):
+    resolved_filters = _resolve_gcovr_filters(
+        coverage_cfg.get("filters", []), source_folder,
+    )
+    for f in resolved_filters:
         cmd.extend(["--filter", f])
     for e in coverage_cfg.get("excludes", []):
         cmd.extend(["--exclude", e])
     cmd.append(str(build_folder))
     _run(cmd)
+    _assert_gcovr_collected_data(json_summary, build_folder, resolved_filters)
     return json_summary
 
 


### PR DESCRIPTION
Closes #71

## Summary

`coverage_generator.py` was looking for pytest-cov outputs at `<build_folder>/cov-py-summary.json` (the conan-managed build root), but the recipe's `run_python_tests` writes them into a layout-specific subdirectory (`<build_folder>/build/<build_type>/`). The `if exists()` guards silently fell through, `py_summary.exists()` returned False on the fallback path, and `py_raw` defaulted to `0.0` — explaining the "Python: 0.0%" line in xmscore's Coverage workflow against 2.14.2 even though pytest-cov had genuinely produced reports.

Implements the reviewer's brief from #70 verbatim: `rglob`-based artifact lookup that's tolerant of recipe layout choices.

## Fix

New helper `_find_pytest_cov_artifact(build_folder, name)`:

- `rglob`s under the build folder for the named artifact (file or directory)
- Returns the match, or `None` when truly absent (legitimate `pybind=False` case)
- When >1 candidate exists (e.g. stale leftover from a prior build type), picks the newest by `st_mtime` and logs a warning naming all candidates

`run_coverage` then uses the helper for all three pytest-cov outputs: `cov-py-summary.json`, `cov-py.xml`, and `coverage-html-py/`.

## Test plan

- [x] `python -m pytest` — **510 passed, 1 skipped** (up from 505; 5 new)
- [x] `python -m flake8` on touched files — clean
- [x] New `TestFindPytestCovArtifact` class:
  - `test_finds_artifact_at_root` — file at `build_folder/` is returned
  - `test_finds_artifact_in_layout_subdir` — file at `build_folder/build/Debug/` is returned (the xmscore case)
  - `test_returns_none_when_absent` — `pybind=False` / no-Python case returns `None` without raising
  - `test_picks_newest_on_collision_and_warns` — two candidates, newer wins by `mtime`, warning logged
- [x] `TestRunCoverageThresholdGating::test_finds_python_artifacts_in_layout_subdir` — pins the end-to-end behavior: stage `cov-py-summary.json` + `cov-py.xml` + `coverage-html-py/` at `build_folder/build/Debug/`, run `run_coverage`, assert all three are hoisted up to the workspace root AND that `py_raw` reflects the staged 82.5% (not the silent 0.0 default).
- [x] Existing `TestRunCoverageThresholdGating` tests pass unchanged — they stage files at the root of `build_folder`; the new `rglob` lookup still finds them there.

## Docs

No user-facing surface changed — internal helper + path lookup.

## What this unblocks

Combined with the previous coverage-rollout PRs, this should be the final piece needed for xmscore's Coverage workflow to produce a real two-layer report. Plan: cut **2.14.3** with PR #70 (C++ XMS_COVERAGE buildenv) and this PR (Python artifact path lookup) bundled, then re-trigger xmscore's Coverage workflow and post the resulting `coverage-xml` artifact contents as the long-awaited green baseline.