### PR TITLE
Emit actions/checkout@v4 in generated GitHub CI templates

### DIFF
--- a/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
+++ b/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
@@ -31,7 +31,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -99,7 +99,7 @@ jobs:
           clang --version
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -247,7 +247,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
@@ -390,7 +390,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
@@ -528,7 +528,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/xmsconan/generator_tools/ci_templates/github-coverage.yaml.jinja
+++ b/xmsconan/generator_tools/ci_templates/github-coverage.yaml.jinja
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python 3.13
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

The generated GitHub workflows still pinned `actions/checkout@v2`, so every regeneration reverted consuming repos to a deprecated action.

This surfaced during the xmsconan 2.15.3 rollout: xmsgrid had already been upgraded to `@v4` by hand in b20fc15 ("Address PR #186 follow-up review issues"), and regenerating with 2.15.3 silently undid that reviewed change.

xmsconan's own CI has run `checkout@v4` for some time (`.github/workflows/xmsconan-ci.yaml` lines 19/50/83) — only the templates it emits were left behind.

## Changes

- `github-ci.yaml.jinja`: 5 occurrences `@v2` → `@v4`
- `github-coverage.yaml.jinja`: 1 occurrence `@v2` → `@v4`

## Verification

```
539 passed, 5 skipped
flake8 . -> exit 0
```

No test or golden file asserts the checkout version, so nothing else needed updating.

## Follow-up

Needs a 2.15.4 release before the in-flight suite-wide bump can continue — generated CI pins `xmsconan==<generating version>`, so consumers must regenerate against 2.15.4 to pick this up.