### PR TITLE
Fix undefined need in generated GitLab Windows deploy job

### DIFF
--- a/tests/test_ci_yaml_validation.py
+++ b/tests/test_ci_yaml_validation.py
@@ -169,6 +169,47 @@ def test_gitlab_ci_stages_match_jobs(options, tmp_path):
             )
 
 
+@pytest.mark.parametrize("options", _OPTION_COMBOS, ids=_combo_id)
+def test_gitlab_ci_needs_reference_defined_jobs(options, tmp_path):
+    """Every 'needs' entry names a defined job and uses no unexpanded variables.
+
+    GitLab does not expand variables inside needs:parallel:matrix.  A selector
+    such as "PYTHON_TARGET_VERSION: $PYTHON_TARGET_VERSION" is compared as a
+    literal, matches no job, and fails the entire pipeline at config time with
+    "undefined need" — producing zero jobs rather than a failing job.
+    """
+    toml_file = _write_toml(tmp_path, "gitlab", options)
+    output_dir = tmp_path / "output"
+    generate_ci(str(toml_file), "1.0.0", str(output_dir))
+
+    ci_file = output_dir / ".gitlab-ci.yml"
+    parsed = yaml.safe_load(ci_file.read_text(encoding="utf-8"))
+
+    non_job_keys = {"stages", "variables", "pages"}
+    job_names = {
+        key for key, value in parsed.items()
+        if key not in non_job_keys and isinstance(value, dict)
+    }
+
+    for key, value in parsed.items():
+        if key in non_job_keys or not isinstance(value, dict):
+            continue
+        for entry in value.get("needs", []):
+            needed = entry["job"] if isinstance(entry, dict) else entry
+            assert needed in job_names, (
+                f"Job '{key}' needs '{needed}', which is not a defined job"
+            )
+            if not isinstance(entry, dict):
+                continue
+            for selector in entry.get("parallel", {}).get("matrix", []):
+                for var, selected in selector.items():
+                    assert "$" not in str(selected), (
+                        f"Job '{key}' needs '{needed}' with an unexpanded "
+                        f"variable in its matrix selector: {var}={selected}. "
+                        f"GitLab compares these literally."
+                    )
+
+
 # ---------------------------------------------------------------------------
 # Cross-template consistency
 # ---------------------------------------------------------------------------

--- a/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
+++ b/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
@@ -237,11 +237,15 @@ Repair Wheel:
       - PYTHON_TARGET_VERSION: '<< v >>'
         PY_TAG: 'py<< v | replace(".", "") >>'
 <% endfor %>
+  # Depend on the whole build job rather than selecting one parallel instance.
+  # GitLab does not expand variables inside needs:parallel:matrix, so a selector
+  # like "PYTHON_TARGET_VERSION: $PYTHON_TARGET_VERSION" is compared literally,
+  # matches no job, and fails the whole pipeline at config time with
+  # "undefined need". Listing the matrix values instead would make every deploy
+  # instance need every build instance anyway, so this is equivalent and cannot
+  # drift out of sync with the matrix above.
   needs:
     - job: "Conan Build - Windows"
-      parallel:
-        matrix:
-          - PYTHON_TARGET_VERSION: $PYTHON_TARGET_VERSION
       artifacts: true
   artifacts:
     expire_in: '1d'


### PR DESCRIPTION
## Summary

The generated `Conan Deploy - Windows` job selected its build counterpart with:

```yaml
  needs:
    - job: "Conan Build - Windows"
      parallel:
        matrix:
          - PYTHON_TARGET_VERSION: $PYTHON_TARGET_VERSION
```

GitLab does not expand variables inside `needs:parallel:matrix`. The value is compared literally, matches no job, and fails the pipeline **at config time**:

```
Conan Deploy - Windows: [3.13, py313] job: undefined need:
  Conan Build - Windows: [$PYTHON_TARGET_VERSION]
```

The failure mode is nasty: the pipeline produces **zero jobs** rather than a failing job, so it reads as a mysterious red pipeline with nothing to inspect.

Found during the suite-wide 2.15.4 rollout — xmsconstraint's regenerated `.gitlab-ci.yml` was invalid and two pipelines created no jobs at all. Repos without a Windows deploy matrix (xmsvtk, xmslidar) lint clean and were unaffected.

## Fix

Depend on the whole build job. Listing the matrix values would make every deploy instance need every build instance anyway, so this is equivalent — and it cannot drift out of sync with the matrix above it.

## Test

`test_gitlab_ci_needs_reference_defined_jobs` asserts every `needs` entry names a defined job and carries no unexpanded variable in a matrix selector. Verified red/green:

```
pre-fix template:  8 failed, 24 passed   (every windows+deploy combo)
post-fix template: 32 passed
```

## Verification

```
571 passed, 5 skipped   (was 539 + 32 new parametrized cases)
flake8 . -> exit 0
```

## Follow-up

Needs a 2.15.5 release so xmsconstraint can regenerate against a template that produces a valid pipeline.