### PR TITLE
Compile testing_sources into the library except for Python builds

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -95,7 +95,7 @@ Run `xmsconan <cmd> --help` for the full flag set. The legacy underscored names 
 |---|---|---|
 | `library_sources` | `[]` | C++ implementation files (`.cpp`) for the static library. |
 | `library_headers` | `[]` | Public headers exported to consumers. |
-| `testing_sources` | `[]` | `.cpp` files compiled into the test runner only. |
+| `testing_sources` | `[]` | `.cpp` files compiled into the library when `testing=True`, so dependent libraries can link the testing helpers. Excluded from Python builds — see the note below. |
 | `testing_headers` | `[]` | Test fixture / helper headers (`*.t.h` for cxxtest). |
 | `python_library_sources` | `[]` | C++ files compiled only when `pybind=True`. |
 | `python_library_headers` | `[]` | Headers compiled only when `pybind=True`. |
@@ -103,6 +103,28 @@ Run `xmsconan <cmd> --help` for the full flag set. The legacy underscored names 
 | `pybind_headers` | `[]` | Pybind11 binding headers. |
 
 Paths are interpreted relative to the directory `build.toml` lives in.
+
+#### Where `testing_sources` end up
+
+Under `testing=True` they are compiled into the library itself, and the test
+runner picks them up by linking it. This is deliberate: xms libraries publish
+testing helpers (xmscore's `ttEqualPointsXYZ`, `ttTextFilesEqual`, ...) that
+downstream libraries link from the package they already consume, so the helpers
+have to live in the library that gets packaged.
+
+Under `pybind=True` they are excluded from the library and the runner compiles
+them directly instead. The pybind module links the main library, and these
+translation units reference cxxtest helpers such as `CxxTest::charToString` —
+declared in `cxxtest/ValueTraits.h` but defined only in
+`cxxtest/ValueTraits.cpp`, which is pulled in solely by the cxxtestgen-generated
+`runner.cpp`. A pybind module carrying them fails `dlopen` with an undefined
+symbol.
+
+The two options are never combined in a generated configuration (the packager
+fans out `wchar_t`, `pybind` and `testing` independently rather than
+cross-multiplying), so in practice `testing=True` always means the helpers are
+in the library. The `IS_PYTHON_BUILD` guard exists for hand-built and
+option-overridden configurations.
 
 ### 5.3 Dependencies
 

--- a/tests/test_build_file_generator.py
+++ b/tests/test_build_file_generator.py
@@ -418,6 +418,64 @@ def test_cmake_template_emits_source_group_tree(tmp_path):
         assert f'"{var}"' not in content, f"{var} must not be quoted in source_group call"
 
 
+@pytest.mark.parametrize("framework", ["cxxtest", "gtest"])
+def test_testing_sources_are_compiled_into_the_library(framework, tmp_path):
+    """testing_sources go into the library, guarded against Python builds.
+
+    xms libraries publish testing helpers (xmscore's ``ttEqualPointsXYZ``,
+    ``ttTextFilesEqual``, ...) that dependent libraries link out of the package
+    they already consume, so the helpers must be in the packaged library rather
+    than only in the test runner.
+
+    The ``IS_PYTHON_BUILD`` guard keeps them out of the pybind module, whose
+    link closure contains no definition of cxxtest's ``CxxTest::charToString``
+    (defined only in ``cxxtest/ValueTraits.cpp``, pulled in solely by the
+    cxxtestgen-generated ``runner.cpp``).
+
+    Both directions are asserted, because losing either one is silent: the
+    library loses helpers downstream libraries link, or the pybind module
+    regains an undefined symbol that only shows up at dlopen time.
+    """
+    toml_file = tmp_path / "build.toml"
+    toml_file.write_text(
+        'library_name = "xmscore"\n'
+        'description = "desc"\n'
+        'python_namespaced_dir = "core"\n'
+        f'testing_framework = "{framework}"\n'
+        'library_sources = []\n'
+        'library_headers = []\n'
+        'testing_sources = ["xmscore/testing/TestTools.cpp"]\n'
+        'testing_headers = []\n'
+        'pybind_sources = []\n'
+        'pybind_headers = []\n',
+        encoding="utf-8",
+    )
+
+    tpl_dir = tmp_path / "tpl"
+    tpl_dir.mkdir()
+    _copy_template("CMakeLists.txt.jinja", tpl_dir)
+
+    output_dir = tmp_path / "output"
+    render_template_with_toml(
+        toml_file_path=str(toml_file),
+        version="1.0.0",
+        template_dir=str(tpl_dir),
+        output_dir=str(output_dir),
+    )
+
+    content = (output_dir / "CMakeLists.txt").read_text(encoding="utf-8")
+
+    # The library picks them up for non-Python builds.
+    assert "if (NOT IS_PYTHON_BUILD)" in content
+    assert "list(APPEND xmscore_sources ${xmscore_testing_sources})" in content
+
+    # The runner compiles them itself ONLY for Python builds, where the library
+    # does not carry them. Compiling them unconditionally would duplicate every
+    # translation unit against the library's copy.
+    assert "if (IS_PYTHON_BUILD AND xmscore_testing_sources)" in content
+    assert "target_sources(runner PRIVATE ${xmscore_testing_sources})" in content
+
+
 def test_generates_build_py_with_test_shards(build_toml, tmp_path):
     """build.py is generated with --test-shards argument and auto mode logic."""
     tpl_dir = tmp_path / "tpl"

--- a/xmsconan/generator_tools/templates/CMakeLists.txt.jinja
+++ b/xmsconan/generator_tools/templates/CMakeLists.txt.jinja
@@ -121,17 +121,28 @@ if (BUILD_TESTING)
          {%- for header in testing_headers -%}{{ '\n         ' }}{{ header }}{% endfor %}
     )
 
-    # testing_sources are deliberately NOT appended to {{ library_name }}_sources.
-    # They are compiled directly into the runner target below (per the documented
-    # contract: "testing_sources are compiled into the test runner only").
-    # Putting them in the main static library makes them leak into anything that
-    # links the library — including the pybind module under IS_PYTHON_BUILD —
-    # which produces undefined-symbol errors against cxxtest helpers like
-    # CxxTest::charToString (defined only in cxxtest/ValueTraits.cpp, which is
-    # not transitively pulled by ValueTraits.h).
     set({{ library_name }}_testing_sources
         {%- for source in testing_sources -%}{{ '\n        ' }}{{ source }}{% endfor %}
     )
+
+    # testing_sources are compiled into the main library so dependent libraries
+    # can link the testing helpers (xmscore's ttEqualPointsXYZ, ttTextFilesEqual,
+    # ...) out of the package they already consume.
+    #
+    # They are excluded under IS_PYTHON_BUILD. The pybind module links the main
+    # library, and these translation units reference cxxtest helpers such as
+    # CxxTest::charToString — declared in cxxtest/ValueTraits.h but defined only
+    # in cxxtest/ValueTraits.cpp, which is pulled in solely by the
+    # cxxtestgen-generated runner.cpp via Root.cpp. A pybind module carrying them
+    # fails dlopen with an undefined symbol.
+    #
+    # The packager never emits pybind=True+testing=True (asserted by
+    # test_pybind_and_testing_are_never_combined_in_one_config), so for generated
+    # configurations this guard is belt-and-braces; it protects hand-built and
+    # option-overridden builds.
+    if (NOT IS_PYTHON_BUILD)
+        list(APPEND {{ library_name }}_sources ${{ '{' }}{{ library_name }}_testing_sources})
+    endif ()
 {% if testing_framework == "gtest" %}
     # Google Test configuration
     # Tests are in *.cpp files guarded by #ifdef GTEST_ENABLED, with fixtures declared in *.t.h
@@ -168,8 +179,14 @@ if (BUILD_TESTING)
     add_executable(runner
         ${CMAKE_CURRENT_BINARY_DIR}/runner.cpp
         ${test_cpp_sources}
-        ${{ '{' }}{{ library_name }}_testing_sources}
     )
+    # Only under IS_PYTHON_BUILD are the testing sources absent from the library
+    # (see above), so only then must the runner compile them itself. Otherwise it
+    # picks them up by linking ${PROJECT_NAME}, and compiling them here as well
+    # would duplicate every translation unit.
+    if (IS_PYTHON_BUILD AND {{ library_name }}_testing_sources)
+        target_sources(runner PRIVATE ${{ '{' }}{{ library_name }}_testing_sources})
+    endif ()
     target_link_libraries(runner
         ${PROJECT_NAME}
         GTest::gtest
@@ -249,7 +266,11 @@ if (BUILD_TESTING)
         CXXTEST_ADD_TEST(
                 runner runner.cpp ${test_headers}
         )
-        if ({{ library_name }}_testing_sources)
+        # Only under IS_PYTHON_BUILD are the testing sources absent from the
+        # library (see above), so only then must the runner compile them itself.
+        # Otherwise it picks them up by linking ${PROJECT_NAME}, and compiling
+        # them here as well would duplicate every translation unit.
+        if (IS_PYTHON_BUILD AND {{ library_name }}_testing_sources)
             target_sources(runner PRIVATE ${{ '{' }}{{ library_name }}_testing_sources})
         endif ()
         target_link_libraries(runner ${PROJECT_NAME})


### PR DESCRIPTION
## Summary

xms libraries publish testing helpers — xmscore's `ttEqualPointsXYZ`, `ttTextFilesEqual` and friends — that dependent libraries link out of the package they already consume. 2.15.1 moved `testing_sources` out of the library into the runner target, so any library built since stopped exporting them:

```
undefined reference to `xms::ttTextFilesEqual(...)'
undefined reference to `xms::ttEqualPointsXYZ(...)'
```

**71 files across six downstream repos** depend on those symbols (xmsconstraint 27, xmsmesher 19, xmsgrid 14, xmsinterp 7, xmsextractor 3, xmsgridtrace 1). It surfaced now because the suite is moving off xmscore 7.0.8 — released 2026-05-06, eight days before 2.15.1, and the last xmscore whose library carries the helpers.

## Why this is safe now

2.15.1 was fixing a real bug: under the `pybind=True+testing=True` coverage config that 2.15.0 introduced, testing sources in the library leaked unresolved CxxTest symbols into the pybind module, which failed `dlopen`.

Three days later **2.15.2 removed that combination entirely** — coverage became two independent builds (`testing=True+pybind=False` for CxxTest, `testing=False+pybind=True` for pytest-cov), and `test_pybind_and_testing_are_never_combined_in_one_config` asserts the packager can never emit it. The configuration 2.15.1 was defending against no longer exists.

## Change

```cmake
if (NOT IS_PYTHON_BUILD)
    list(APPEND ${library}_sources ${${library}_testing_sources})
endif ()
```

The guard is in CMake rather than relying on the packager invariant, so hand-built and option-overridden configurations stay protected. The runner compiles `testing_sources` itself **only** under `IS_PYTHON_BUILD`; otherwise it gets them by linking the library, so nothing is compiled twice. Both cxxtest and gtest paths updated.

## Coverage is unaffected

gcovr is driven by paths, not targets — `--root <build_folder>` plus `--filter '<library_name>/'`. `TestTools.cpp` is instrumented in the C++ coverage build either way and matches the filter either way. The Python coverage build has `testing=False`, so no testing sources exist in it at all.

## Docs

`docs/USAGE.md` §5.2 claimed `testing_sources` are "compiled into the test runner only". That line was added **2026-05-05** and never matched the implementation, which had put them in the library since the generator was written in **2025-01**. Nine days later it became the stated justification for 2.15.1. Replaced with the real contract plus a note explaining both placements and why.

## Test

`test_testing_sources_are_compiled_into_the_library`, parametrized over cxxtest and gtest, asserts **both** directions — the library append is present, and the runner's copy is guarded by `IS_PYTHON_BUILD`. Losing either is silent otherwise. Verified red/green: 2 failed pre-change, 2 passed post-change.

This is the regression guard that was missing in May — the 2.15.0 canary passed because the stub fixture had no `testing_sources` at all.

## Verification

```
573 passed, 5 skipped   (was 571 + 2 new parametrized cases)
flake8 . -> exit 0
```

Also rendered xmscore's real `build.toml` and confirmed the append lands at line 180, before `add_library` at line 267.

## Follow-up

Needs a **2.16.0** release (it changes what the published library contains), then xmscore re-released so there is a build carrying the helpers *and* built under `conan~=2.31.0` — which is what unblocks xmsgrid and the rest of the cascade.