### PR TITLE
Reset mtimes on libraries staged for wheel repair

### DIFF
--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -1,4 +1,5 @@
 """Tests for package_tools.packager."""
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -867,3 +868,60 @@ def test_run_sharded_tests_handles_timeout(mock_run, tmp_path):
 
     result = p.run()
     assert result > 0  # one shard failed
+
+
+# --- collect_dependency_libs ---
+
+
+# 1980-01-01 UTC; ZIP timestamps cannot go earlier.
+ZIP_EPOCH = 315532800
+
+
+@patch("xmsconan.package_tools.packager.subprocess.run")
+def test_collect_dependency_libs_rewrites_pre_1980_mtimes(mock_run, tmp_path):
+    """Verify staged libraries get a ZIP-representable mtime.
+
+    Conan zeroes mtimes in package tarballs, so libraries restored from a
+    remote are dated 1970. Copying that mtime through to the staging dir
+    makes the wheel repair tools fail with "ZIP does not support
+    timestamps before 1980".
+    """
+    conan_home = tmp_path / "conan_home"
+    pkg_dir = conan_home / "p" / "somepkg" / "p" / "bin"
+    pkg_dir.mkdir(parents=True)
+    for name in ("msvcp140.dll", "libfoo.dylib", "libbar.so"):
+        lib = pkg_dir / name
+        lib.write_bytes(b"MZ")
+        os.utime(lib, (0, 0))
+
+    mock_run.return_value = subprocess.CompletedProcess(
+        [], 0, stdout=f"{conan_home}\n"
+    )
+
+    output_dir = tmp_path / "libs"
+    XmsConanPackager("xmsvtk").collect_dependency_libs(str(output_dir))
+
+    staged = sorted(p.name for p in output_dir.iterdir())
+    assert staged == ["libbar.so", "libfoo.dylib", "msvcp140.dll"]
+    for lib in output_dir.iterdir():
+        assert lib.stat().st_mtime >= ZIP_EPOCH, f"{lib.name} is not ZIP-representable"
+
+
+@patch("xmsconan.package_tools.packager.subprocess.run")
+def test_collect_dependency_libs_skips_non_libraries(mock_run, tmp_path):
+    """Verify only shared libraries are staged."""
+    conan_home = tmp_path / "conan_home"
+    pkg_dir = conan_home / "p" / "somepkg" / "p" / "bin"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "libbaz.so.1.2").write_bytes(b"\x7fELF")
+    (pkg_dir / "readme.txt").write_text("not a library")
+    (pkg_dir / "tool.exe").write_bytes(b"MZ")
+
+    mock_run.return_value = subprocess.CompletedProcess(
+        [], 0, stdout=f"{conan_home}\n"
+    )
+
+    output_dir = tmp_path / "libs"
+    XmsConanPackager("xmsvtk").collect_dependency_libs(str(output_dir))
+
+    assert sorted(p.name for p in output_dir.iterdir()) == ["libbaz.so.1.2"]

--- a/xmsconan/package_tools/packager.py
+++ b/xmsconan/package_tools/packager.py
@@ -574,6 +574,12 @@ class XmsConanPackager(object):
         Scans all packages in the Conan cache and copies shared libraries
         (.so, .dylib, .dll) into output_dir so repair tools can find them.
 
+        Copied libraries have their modification time reset to now. Conan
+        zeroes mtimes in package tarballs, so libraries restored from a
+        remote land in the cache dated 1970. The repair tools (delvewheel,
+        auditwheel, delocate) write these libraries into the wheel's ZIP
+        archive, and ZIP cannot represent timestamps before 1980.
+
         Args:
             output_dir: Directory to copy shared libraries into.
         """
@@ -596,6 +602,7 @@ class XmsConanPackager(object):
                     dst = os.path.join(output_dir, fname)
                     if not os.path.exists(dst):
                         shutil.copy2(os.path.join(root, fname), dst)
+                        os.utime(dst, None)
                         count += 1
         self.printer.print_message(f'Collected {count} shared libraries to {output_dir}')
 


### PR DESCRIPTION
collect_dependency_libs copies every shared library out of the Conan cache with shutil.copy2, which preserves the source mtime. Conan zeroes mtimes in package tarballs, so any library restored from a remote lands in the cache dated 1970-01-01. The repair tools write the staged libraries into the wheel's ZIP archive, and ZIP cannot represent timestamps before 1980, so delvewheel aborts on repackage:

  File "delvewheel/_wheel_repair.py", line 1144, in repair
    zip_info = zipfile.ZipInfo.from_file(file_path, zip_file_name)
  ValueError: ZIP does not support timestamps before 1980

xmsvtk 0.0.23 hit this on Windows: 793 of the 992 staged DLLs were dated 1970, including the msvcp140.dll that is the only library that wheel vendors. Whether a publish trips over it is chance — the cache walk stages the first copy of a given filename it encounters and skips later duplicates, so a locally built package can shadow a downloaded one. 0.0.21 published from the same machine seven weeks earlier because a different msvcp140.dll won the walk.

SOURCE_DATE_EPOCH is not a workaround. delvewheel calls ZipInfo.from_file before applying its date_time override, so the ValueError is raised first.

Reset each staged library's mtime to now. auditwheel and delocate build the same ZIP archives, so this covers the Linux and macOS paths as well.

Adds test_collect_dependency_libs_rewrites_pre_1980_mtimes, which fails against the pre-fix implementation with "assert 0.0 >= 315532800", and a companion asserting only shared libraries are staged.