### PR TITLE
Float the generated xmsconan pin on >= instead of pinning with ==

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -364,21 +364,21 @@ The generated jobs follow the pattern:
 - Wheel-repair always runs `cp313-cp313`'s `xmsconan_wheel_repair` inside the manylinux container; auditwheel itself doesn't care about the host Python.
 - Required CI variables: `AQUAPI_URL`, `AQUAPI_USERNAME`, `AQUAPI_PASSWORD` (for wheel deploy).
 
-### 10.3 Pinned tool versions
+### 10.3 Toolchain versions
 
-Build and deploy jobs pin the toolchain rather than floating it:
+Generated jobs constrain the two tools they install, in opposite directions:
 
 | Tool | Spec | Why |
 |---|---|---|
-| `xmsconan` | `==<version that generated the file>` | xmsconan owns the Conan profiles, so a new release can change `compiler.version` — and therefore **every package_id** — under a repo that has not changed a line. |
+| `xmsconan` | `>=<version that generated the file>`, always with `--upgrade` | An xmsconan fix reaches a repo on its next CI run, rather than requiring a regenerate-and-commit pass across the whole suite. The floor still rules out resolving a version older than the templates were generated against. |
 | `conan` | `~=2.31.0` (patch series) | Conan computes package_ids and runs the compatibility plugin; a minor bump can silently detach a build from binaries already on the remote. |
 
-The GitHub `Coverage.yaml` workflow is the deliberate exception and still floats on `>=` — it is the canary that surfaces xmsconan regressions early (see §11.4).
+**`--upgrade` is not optional on the xmsconan install.** pip treats an already-satisfied constraint as a no-op, so on a runner image with xmsconan baked in, the floor alone installs nothing and the job silently runs whatever version the image happens to carry. `test_xmsconan_installs_float_and_upgrade` asserts both halves — the `>=` and the `--upgrade` — across every CI option combination for both templates.
 
 Two consequences worth knowing:
 
-- **Generate CI from a released xmsconan.** With `==`, a workflow generated from an unreleased working copy pins a version that is not on devpi (e.g. `2.15.3.dev2`) and CI will fail to install it.
-- **Upgrades are explicit.** Picking up a new xmsconan or Conan means re-running `xmsconan ci` (and bumping the `conan~=` value in the CI templates) and committing the result — a reviewable change instead of a silent one.
+- **An xmsconan release reaches every repo on its next CI run.** That is the point of the floor, but it cuts both ways: a bad release is suite-wide immediately, and the committed CI file no longer records which xmsconan actually ran. The sharpest edge is that xmsconan owns the Conan profiles — a release that changes a profile's `compiler.version` changes **every package_id**, for every repo, without any repo changing a line. Treat profile changes with the same care as a breaking API change.
+- **Generate CI from a released xmsconan.** A workflow generated from an unreleased working copy writes a floor that nothing on devpi satisfies yet (e.g. `>=2.16.1.dev1` while the newest release is `2.16.0`), and CI fails at `pip install`. Unlike the old `==` pin, this one self-heals: the same file starts working once that version ships.
 
 ---
 
@@ -423,7 +423,7 @@ If the library needs an X server to run its tests (VTK, GUI libs), `xmsconan cov
 ### 11.4 GitLab vs GitHub
 
 - **GitLab**: `xmsconan ci` emits a `Coverage` stage that invokes `xmsconan_coverage` (the legacy alias used throughout the generated CI for consistency with `xmsconan_gen`, `xmsconan_conan_setup`, etc.; equivalent to `xmsconan coverage`), exposes `cov-cpp.xml` as the `cobertura` coverage report, and ships HTML to Pages. The `coverage:` regex still matches gcovr's `TOTAL` line (the `--txt` summary is printed to stdout). The `pages` stage publishes a small landing page at the Pages root linking both `cpp/` and `python/` reports (the Python link is dropped if Python coverage was not produced).
-- **GitHub**: `xmsconan ci` emits a separate `Coverage.yaml` workflow that runs on `push` and `pull_request`, uploads `coverage-html-*/` and `cov-*.xml` as artifacts, and appends a summary table to the run page. The workflow runs directly on `ubuntu-latest` (no docker container) and pip-installs `--upgrade xmsconan>=…` on every run, so the Coverage canary always exercises the latest xmsconan on devpi. Setting `[ci].xvfb = true` apt-installs `xvfb` as an extra step; `[ci].docker_image` is honored by the build/deploy workflows but not by Coverage.
+- **GitHub**: `xmsconan ci` emits a separate `Coverage.yaml` workflow that runs on `push` and `pull_request`, uploads `coverage-html-*/` and `cov-*.xml` as artifacts, and appends a summary table to the run page. The workflow runs directly on `ubuntu-latest` (no docker container), which is what lets the `--upgrade xmsconan>=…` install of §10.3 actually take effect here — the image this job used to run in baked xmsconan in, so the install no-op'd and the canary was locked to whatever the image carried. Setting `[ci].xvfb = true` apt-installs `xvfb` as an extra step; `[ci].docker_image` is honored by the build/deploy workflows but not by Coverage.
 
 ---
 

--- a/tests/test_ci_file_generator.py
+++ b/tests/test_ci_file_generator.py
@@ -314,20 +314,21 @@ def test_gitlab_ci_deploy_false_suppresses_deploy(tmp_path):
     assert "xmsconan_conan_deploy" not in content
 
 
-def test_github_ci_version_bump(ci_toml, tmp_path):
-    """Rendered GitHub CI pins the current xmsconan version.
+def test_github_ci_version_floor(ci_toml, tmp_path):
+    """Rendered GitHub CI floors xmsconan at the generating version.
 
-    Build and deploy jobs pin with ``==`` so an xmsconan release cannot change
-    the Conan profiles (and therefore every package_id) underneath a repo that
-    has not changed. The Coverage canary intentionally still floats on ``>=``.
+    Every job installs ``xmsconan>=<version that generated the file>`` rather
+    than pinning with ``==``, so a repo picks up an xmsconan release without
+    regenerating and committing its CI. The floor still rules out resolving a
+    version older than the templates were written against.
     """
     from xmsconan import __version__
     output_dir = tmp_path / "output"
     generate_ci(str(ci_toml), "1.0.0", str(output_dir))
     ci_file = output_dir / ".github" / "workflows" / "XmsCore-CI.yaml"
     content = ci_file.read_text(encoding="utf-8")
-    assert f"xmsconan=={__version__}" in content
-    assert "xmsconan>=" not in content
+    assert f"xmsconan>={__version__}" in content
+    assert "xmsconan==" not in content
 
 
 def test_github_flake_job_uses_generated_flake8_config(ci_toml, tmp_path):

--- a/tests/test_ci_yaml_validation.py
+++ b/tests/test_ci_yaml_validation.py
@@ -235,13 +235,51 @@ def test_both_templates_reference_same_xmsconan_version(tmp_path):
     ).read_text(encoding="utf-8")
     gl_content = (gl_out / ".gitlab-ci.yml").read_text(encoding="utf-8")
 
-    # Extract all xmsconan==X.Y.Z references
+    # Extract all xmsconan>=X.Y.Z references
     import re
-    gh_versions = set(re.findall(r"xmsconan==([\d.]+)", gh_content))
-    gl_versions = set(re.findall(r"xmsconan==([\d.]+)", gl_content))
+    gh_versions = set(re.findall(r"xmsconan>=([\d.]+)", gh_content))
+    gl_versions = set(re.findall(r"xmsconan>=([\d.]+)", gl_content))
 
     assert len(gh_versions) == 1, f"GitHub has multiple versions: {gh_versions}"
     assert len(gl_versions) == 1, f"GitLab has multiple versions: {gl_versions}"
     assert gh_versions == gl_versions, (
         f"Version mismatch: GitHub={gh_versions}, GitLab={gl_versions}"
     )
+
+
+@pytest.mark.parametrize("ci_type", ["github", "gitlab"])
+@pytest.mark.parametrize("options", _OPTION_COMBOS, ids=_combo_id)
+def test_xmsconan_installs_float_and_upgrade(ci_type, options, tmp_path):
+    """Every generated xmsconan install floors with >= and passes --upgrade.
+
+    The two halves are one contract. ``>=`` is what lets a repo pick up an
+    xmsconan release without regenerating its CI, but pip treats an
+    already-satisfied constraint as a no-op, so on a runner image with
+    xmsconan baked in the floor alone installs nothing. That is how the
+    2.15.1 fix never reached xmscore CI (see ad248ed): the image carried a
+    version that already satisfied the floor, so pip skipped the install on
+    every run. ``--upgrade`` is what makes the floor actually resolve to the
+    newest release on devpi.
+    """
+    toml_file = _write_toml(tmp_path, ci_type, options)
+    output_dir = tmp_path / "output"
+    generate_ci(str(toml_file), "1.0.0", str(output_dir))
+
+    install_lines = [
+        stripped
+        for path in sorted(output_dir.rglob("*")) if path.is_file()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        # Comments describing the pin are not commands; only executed
+        # install steps carry the contract.
+        if (stripped := line.strip()) and not stripped.startswith("#")
+        if "pip install" in stripped and "xmsconan" in stripped
+    ]
+    assert install_lines, f"no xmsconan install rendered for {ci_type} {options}"
+
+    for line in install_lines:
+        assert "xmsconan==" not in line, f"pinned rather than floored: {line}"
+        assert "xmsconan>=" in line, f"no version floor: {line}"
+        assert "--upgrade" in line, (
+            f"floor without --upgrade is a no-op when the runner image "
+            f"already carries a satisfying xmsconan: {line}"
+        )

--- a/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
+++ b/xmsconan/generator_tools/ci_templates/github-ci.yaml.jinja
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
-          pip install "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Generate .flake8 so CI lints with the same config developers use locally.
       # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
       # the two copies drift apart silently.
@@ -113,7 +113,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -255,7 +255,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -398,7 +398,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -547,7 +547,7 @@ jobs:
           # package_id computation and silently detach builds from the binaries
           # already published to the remote. Bump this deliberately.
           pip install "conan~=2.31.0" devpi-client wheel
-          python -m pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2

--- a/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
+++ b/xmsconan/generator_tools/ci_templates/gitlab-ci.yml.jinja
@@ -55,7 +55,8 @@ Conan Build:
     - gcc --version
     - cmake --version
     - python --version
-    - pip install "conan~=2.31.0" "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install "conan~=2.31.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_conan_setup
     - export PACKAGE_VERSION=${CI_COMMIT_TAG:-0.0.0}
     - export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-8}
@@ -159,7 +160,7 @@ Conan Build:
     - echo ${PACKAGE_VERSION}
     - python --version
     - pip install "conan~=2.31.0" toml packaging devpi-client
-    - python -m pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - python -m pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_conan_setup
     - xmsconan_gen --version ${PACKAGE_VERSION} build.toml
     - python build.py --version ${PACKAGE_VERSION} --artifacts-dir test_artifacts
@@ -175,7 +176,7 @@ Lint:
   script:
     - pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming flake8-colors flake8-tidy-imports
     - pip install -i https://aquapi.aquaveo.com/aquaveo/dev/+simple/ flake8-aquaveo
-    - pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_gen --version 0.0.0 build.toml
     - flake8 _package
 
@@ -191,7 +192,7 @@ Repair Wheel:
   dependencies:
     - Conan Build
   script:
-    - /opt/python/cp313-cp313/bin/pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - /opt/python/cp313-cp313/bin/pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - /opt/python/cp313-cp313/bin/xmsconan_wheel_repair --wheel-dir wheelhouse
   artifacts:
     expire_in: '1d'
@@ -205,7 +206,7 @@ Repair Wheel:
   dependencies:
     - Repair Wheel
   script:
-    - pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_wheel_deploy --wheel-dir wheelhouse
   only:
     - tags
@@ -220,7 +221,8 @@ Repair Wheel:
     - apt-get install -y python3-pip python3-venv
     - python3 -m venv .venv
     - source .venv/bin/activate
-    - pip install "conan~=2.31.0" "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install "conan~=2.31.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_conan_setup
     - export PACKAGE_VERSION=${CI_COMMIT_TAG:-0.0.0}
     - xmsconan_conan_deploy << library_name >> ${PACKAGE_VERSION} --restore .export/<< library_name >>-linux-${PACKAGE_VERSION}.tar.gz --upload
@@ -253,7 +255,8 @@ Repair Wheel:
       - conan_packages/
   script:
     - export PACKAGE_VERSION=${CI_COMMIT_TAG:-0.0.0}
-    - pip install "conan~=2.31.0" "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install "conan~=2.31.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_conan_setup
     - xmsconan_conan_deploy << library_name >> ${PACKAGE_VERSION} --restore .export/<< library_name >>-windows-py${PYTHON_TARGET_VERSION}-${PACKAGE_VERSION}.tar.gz --upload
     - mkdir -p conan_packages
@@ -282,7 +285,7 @@ Coverage:
 <% endif %>
   script:
     - pip install "conan~=2.31.0" "gcovr>=7,<9"
-    - pip install --upgrade "xmsconan==<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+    - pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
     - xmsconan_conan_setup
     - export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-8}
     - export PACKAGE_VERSION=${CI_COMMIT_TAG:-0.0.0}


### PR DESCRIPTION
Generated CI now installs `xmsconan>=<version that generated the file>` instead of pinning with `==`, so an xmsconan release reaches a repo on its next CI run rather than requiring a regenerate-and-commit pass across the whole suite.

## Why

2.15.3 (`7b470fb`) introduced the `==` pin so an xmsconan release could not change the Conan profiles — and therefore every package_id — under a repo that had not changed a line. That reasoning is sound, but 2.16.1 showed its cost: a fix living entirely in the installed package (`collect_dependency_libs` resetting pre-1980 mtimes) still could not reach a single repo until each one regenerated and committed its CI, because the `==` pin keeps installing whatever version was current when the file was generated.

## What changed

### 1. All 13 pins float on `>=`

5 in `github-ci.yaml.jinja`, 8 in `gitlab-ci.yml.jinja`. `github-coverage.yaml.jinja` already floated and is untouched.

### 2. Four install lines gained `--upgrade` — this half matters more

pip treats an already-satisfied constraint as a no-op, so on a runner image with xmsconan baked in, `>=` installs **nothing** and the job silently runs whatever the image carries. That is not hypothetical: it is how the 2.15.1 fix never reached xmscore CI for a full release cycle (`ad248ed`). Without this, the `>=` flip would have been a no-op on those four lines.

Missing it were the `github-ci` flake job and the three `gitlab-ci` jobs that co-install conan. For the GitLab three the command is split rather than adding `--upgrade` to the combined install:

```yaml
- pip install "conan~=2.31.0" -i https://…/+simple
- pip install --upgrade "xmsconan>=<< xmsconan_version >>" -i https://…/+simple
```

`--upgrade` on the original one-liner would also have floated conan within its `~=2.31.0` series. Permitted by that specifier, but out of scope here, and conan's pin is load-bearing for package_id stability.

## Tests

- **New** `test_xmsconan_installs_float_and_upgrade` — asserts both halves (`>=` present, `==` absent, `--upgrade` present) on every rendered xmsconan install, across all 32 CI option combinations × both templates = 64 cases. Comment lines are excluded, since only executed steps carry the contract. Verified red/green: **64 failed** against the pre-change templates, 64 pass after.
- **Inverted** `test_github_ci_version_bump` → renamed `test_github_ci_version_floor`; it asserted the `==` contract.
- **Updated** `test_both_templates_reference_same_xmsconan_version` — cross-template version regex was matching on `xmsconan==`.

Full suite: 639 passed, 5 skipped. flake8 clean with the CI plugin set.

## Doc impact

Yes — both in this PR:

- **`docs/USAGE.md` §10.3** retitled ("Pinned tool versions" → "Toolchain versions", since the two tools now go in opposite directions) and rewritten: the `xmsconan` row, a new paragraph on why `--upgrade` is not optional, and reworked consequences. The risk now accepted is stated plainly — a profile change in an xmsconan release moves every package_id suite-wide with no repo changing a line, so profile changes carry the weight of a breaking API change. Also notes that unlike `==`, a floor generated from an unreleased working copy self-heals once that version ships.
- **`docs/USAGE.md` §11.4** no longer calls the Coverage workflow's floor a deliberate exception, since every job floats now; the containerless rationale is kept.

No `build.toml` key, console script, env var, or CI template section was added or renamed, so no other doc surface is affected. `README.md` never mentioned the pin.

## Rollout

Existing repos are **not** on the floor yet. A repo whose CI was generated with `==` keeps installing that exact version — including the file that would deliver this change. Each repo needs one more `xmsconan ci` regeneration, against a release containing this commit, to get onto the floor. After that they float and this class of rollout ends.

This warrants a **minor** bump (2.17.0): it changes the contract of every generated CI file.

## Known follow-ups, not in this PR

- `github-coverage.yaml.jinja:53` installs conan **unpinned** (`pip install conan wheel "gcovr>=7,<9"`). Traced to `3ce6274`, three months before the pin landed — `7b470fb` never touched that file, so this is an oversight rather than a canary exception. The Coverage canary can currently run a conan the build jobs would reject.
- §10.3 still describes `conan~=2.31.0` as a pin. It is really a floor-and-ceiling (`>=2.31.0, ==2.31.*`) that the runner image can win inside, since that install carries no `--upgrade`.
