### PR TITLE
Add Python wheel extraction to the VS2019 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,23 @@ xmsconan_vs2019 upload --library xmscore --version 7.0.0
 
 The recipe forks its third-party dependency *versions* automatically when it sees msvc 192 — the same packages as the modern stack, resolved to the legacy builds the `aquaveo-vs2019` remote publishes msvc 192 binaries for (boost `1.74.0.3`, zlib `1.2.11`). A library whose *sister* dependencies are pinned to a different line on VS2019 declares that itself with the `[vs2019_dependency_overrides]` table in `build.toml` — see `docs/USAGE.md` §7.4 for the recipe attributes and §16 for the full flag reference.
 
-`upload` publishes only `compiler.version=192` binaries and refuses any remote other than `aquaveo-vs2019` unless `--allow-other-remote` is passed, so a mixed local cache can't leak msvc 194 packages onto the legacy remote and a one-word typo can't push legacy packages into the CI remote. It exits nonzero when `conan upload` fails, so a failed publish is never reported as success. `build` exits `1` if a library failed, `2` for a bad request or a machine that can't build, and `3` when nothing was built at all (`docs/USAGE.md` §16.4).
+`upload` publishes only `compiler.version=192` binaries and refuses any remote other than `aquaveo-vs2019` unless `--allow-other-remote` is passed, so a mixed local cache can't leak msvc 194 packages onto the legacy remote and a one-word typo can't push legacy packages into the CI remote. It exits nonzero when `conan upload` fails, so a failed publish is never reported as success. `build` exits `1` if a library failed or a requested wheel never appeared, `2` for a bad request or a machine that can't build, and `3` when nothing was built at all (`docs/USAGE.md` §16.4).
+
+### VS2019 Python wheels — one run per Python version
+
+`build --wheel-dir DIR` copies each pybind package's `.whl` out of the Conan cache and fills `DIR/libs` with the libraries the repair step needs. Repairing and publishing stay separate commands, the same way `build` and `upload` are:
+
+```bash
+# from a Python 3.10 virtual environment with conan + xmsconan installed
+xmsconan vs2019 build --root <root> --version 7.0.0 --python-versions 3.10 \
+    --filter '{"options": {"pybind": true}}' --wheel-dir wheelhouse
+xmsconan_wheel_repair --wheel-dir wheelhouse --platform windows
+xmsconan_wheel_deploy --wheel-dir wheelhouse
+```
+
+Run those from **Git Bash** — PowerShell strips the inner quotes out of `--filter`. Repeat from a 3.13 virtual environment, into a different `--wheel-dir`, for the 3.13 wheel.
+
+**The Python running conan is the target Python.** The recipe hands CMake `Python3_EXECUTABLE = sys.executable` while the generated `CMakeLists.txt` requires `find_package(Python3 ${PYTHON_TARGET_VERSION} EXACT REQUIRED)`. In CI `actions/setup-python` installs the matrix version and conan runs under it; on a workstation you supply it, so a 3.12 venv building `--python-versions 3.10` fails every pybind configuration at CMake configure. `build` checks this against the *filtered* matrix before compiling anything and exits 2 — the other twelve configurations don't care which interpreter is running, so a non-pybind build from any environment still works. Full workflow in `docs/USAGE.md` §16.8.
 
 ## Development
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -326,6 +326,8 @@ What this turns on:
 
 For local builds (`python build.py`), the matrix is single-version: it uses `PYTHON_TARGET_VERSION` from the environment if set, otherwise `3.13`. Per-`python_version` fan-out is currently a CI/Windows-only feature; to build both wheels locally you'd need to invoke `python build.py` once per version (or construct `XmsConanPackager` directly with `python_versions=["3.10", "3.13"]`).
 
+Either way, a local pybind build only works **from an interpreter of the version being built**: the recipe points CMake at `sys.executable` and the generated `CMakeLists.txt` requires that exact version. CI never notices because `actions/setup-python` supplies a matching interpreter; on a workstation you supply it, which is why the VS2019 wheel workflow is one run per Python version from a virtual environment of that version (§16.8).
+
 > **Runner / image expectations.** Opt-in assumes the `GLR-py310` GitLab Windows runner tag exists. The Linux/Mac side keeps using existing `conan-gcc13-py3.13` images, so no new images are required.
 
 ---
@@ -592,9 +594,11 @@ xmsconan_vs2019 build --root E:\code\xms\migration --log-dir .\vs2019-logs --ver
 
 # 4. Read the summary table, then publish
 xmsconan_vs2019 upload --library xmscore --version 7.0.0
+
+# 5. Python wheels are a separate pass, one per Python version — see §16.8
 ```
 
-**`build` and `upload` are separate verbs on purpose: a build never uploads as a side effect.** The run takes hours and its output lands on a remote other people build against, so a human looks at the summary table before anything is published. There is no `--upload` flag on `build`.
+**`build` and `upload` are separate verbs on purpose: a build never uploads as a side effect.** The run takes hours and its output lands on a remote other people build against, so a human looks at the summary table before anything is published. There is no `--upload` flag on `build`. Wheels follow the same rule: `build --wheel-dir` stages them, and `xmsconan_wheel_repair` / `xmsconan_wheel_deploy` are the commands that repair and publish (§16.8).
 
 ### 16.2 `setup`
 
@@ -633,6 +637,9 @@ Run at the end of `setup`, and again at the start of every `build` — a failure
 | Visual Studio 2019 | `vswhere.exe` finds a 16.x install **that carries the C++ toolset** (`-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64`) **and** has a `Microsoft.VCToolsVersion.default.txt`. Reports the install path and the default MSVC toolset version. | Install VS2019 with the *Desktop development with C++* workload. msvc 192 packages can only be built on a machine that has it. |
 | conan client | `conan --version` is on the pinned `~=2.31.0` series. | `pip install "conan~=2.31.0"` |
 | conan remote `aquaveo-vs2019` | The remote appears in `conan remote list` **and is enabled**. `conan remote list` keeps printing disabled remotes as `[… Enabled: False]`, so the name alone is not enough. | `xmsconan_vs2019 setup --password-file <path>`, or `conan remote enable aquaveo-vs2019` if it is merely disabled. |
+| python interpreter *(`build` only)* | The matrix that is actually about to be built contains **no pybind configuration**, or every pybind configuration targets the Python version this shell is running. | Re-run from a virtual environment of the requested version, or pass `--python-versions <the version you are running>`. Full explanation in §16.8. |
+
+The interpreter check is the one check that depends on the *request* rather than the machine, so it runs after the matrix has been generated and `--filter` applied, and prints into the same block. That scoping is deliberate: 12 of the 14 configurations have `pybind=False` and don't care which interpreter is running, so building only those from whatever virtualenv you happen to be in keeps working. `setup` doesn't run it — there is no matrix at that point.
 
 A conan version outside the pinned series is a **failure, not a warning**: a minor bump can change package_id computation and silently detach these hand-built packages from the binaries already on the remote. Same reasoning as the CI pin in §10.3.
 
@@ -649,8 +656,9 @@ A VS2019 carrying only, say, the .NET workload used to pass this check and then 
 | `--continue-on-error` | off | Attempt the next library after one fails. |
 | `--no-generate` | off | Skip the `xmsconan_gen` step and use the `conanfile.py` already in the checkout. |
 | `--log-dir DIR` | — | Redirect each configuration's `conan create` output to `<DIR>/<library>-<config label>.log` and print a one-line pointer instead. A wall of interleaved compiler output is unreadable on a 14-configuration run. The label carries the whole configuration, **runtime included** — `xmscore-Release-static-testing.log`, `xmscore-Debug-dynamic-wchar_typedef.log`, `xmscore-Release-dynamic-pybind-py3.13.log`. Without the runtime the 14 msvc configurations would collapse onto 8 filenames and each static build would overwrite the dynamic build's log. |
-| `--python-versions X.Y [X.Y …]` | `3.10 3.13` | Python versions the pybind variants fan out across. |
-| `--filter JSON` | — | Restrict the matrix, same shape as `build.py --filter`: `'{"build_type": "Release"}'`. |
+| `--python-versions X.Y [X.Y …]` | `3.10 3.13` | Python versions the pybind variants fan out across. A pybind configuration only builds when this matches the Python running conan, so wheels are built one version per run — §16.8. |
+| `--wheel-dir DIR` | — | After the build, copy each pybind package's `.whl` into `DIR` and fill `DIR/libs` with the shared libraries the repair step needs. Repair and publish stay separate commands (§16.8). A run that asked for a wheel and got none exits 1. |
+| `--filter JSON` | — | Restrict the matrix, same shape as `build.py --filter`: `'{"build_type": "Release"}'`. Nested keys are spelled out — `'{"options": {"pybind": true}}'` selects the pybind configurations. |
 | `--version V` | — | Passed to `xmsconan_gen`, and exported as `XMS_VERSION` so it reaches each profile's `[buildenv]` the way CI supplies it. |
 | `--remote-name NAME` | `aquaveo-vs2019` | The remote the preflight check requires. Match it to the `--remote-name` you gave `setup`; a machine set up against a different Artifactory repo otherwise fails preflight (exit 2) on a remote it was never meant to have. |
 
@@ -671,8 +679,8 @@ A single failing configuration does not stop the library — the packager runs t
 | Code | Meaning |
 |---|---|
 | `0` | At least one library built and none failed. |
-| `1` | A library failed. |
-| `2` | The request or the machine was wrong: an unknown `--only`/`--from` name, a `--filter` that isn't a JSON object, a `--python-versions` entry the packager rejects, a `--root` that doesn't exist, a selection that matches no library at all (`--only xmscore --from xmsgrid`, or a `--from` past the last enabled library), a failed preflight, `conan` or `xmsconan_gen` not on `PATH`, or a file the run needed that could not be read or written. The last two are told apart in the message: only an executable that would not start is reported as a `PATH` problem, and a `xmsconan_gen` that is missing stops the run here rather than being counted as one failed library (exit 1) — it would fail identically for every library after it. |
+| `1` | A library failed, **or** `--wheel-dir` was given and no complete set of wheels came out (§16.8). The second case reuses code 1 rather than adding a fourth: the run was asked for an artifact, it ran, and the artifact isn't there — and the `xmsconan_wheel_repair` you'd run next would be handed an empty directory. |
+| `2` | The request or the machine was wrong: an unknown `--only`/`--from` name, a `--filter` that isn't a JSON object, a `--python-versions` entry the packager rejects, a `--root` that doesn't exist, a selection that matches no library at all (`--only xmscore --from xmsgrid`, or a `--from` past the last enabled library), a failed preflight — including the interpreter check in §16.8 — `conan` or `xmsconan_gen` not on `PATH`, or a file the run needed that could not be read or written. The last two are told apart in the message: only an executable that would not start is reported as a `PATH` problem, and a `xmsconan_gen` that is missing stops the run here rather than being counted as one failed library (exit 1) — it would fail identically for every library after it. |
 | `3` | The run completed but **nothing was built** — every selected library was skipped (no checkout, no `build.toml`, or `--filter` matched nothing). Not success: a typo in `--root` used to print a table of skips and exit 0, which any `&&` chain or wrapper script read as "the stack is built". |
 
 ### 16.5 The library list
@@ -725,6 +733,52 @@ Both `--library` and `--version` are required and there is deliberately **no `*`
 - `--remote aquaveo` is one word away from `--remote aquaveo-vs2019` and is **refused** (exit 2) with a message naming the right remote. Pass `--allow-other-remote` if you genuinely mean a different remote, e.g. a scratch repo.
 
 **Exit code 0 means the packages actually landed.** A failing `conan upload` prints the reference, the remote, and conan's exit status, and the subcommand exits 1. `XmsConanPackager.upload()` returns `0`/`1` for this reason; the generated `build.py --upload` (§6) exits 1 on the same signal. `upload` runs no preflight, so `conan` missing from `PATH` surfaces here as exit 2 with a message rather than a traceback.
+
+### 16.8 Python wheels — one run per Python version
+
+The msvc 192 wheels published to Aquaveo's devpi index are built the same way as the Conan packages: by hand, on the VS2019 box. The whole sequence, for Python 3.10:
+
+```bash
+# from a Python 3.10 virtual environment with conan + xmsconan installed
+xmsconan vs2019 build --root <root> --version 7.0.0 --python-versions 3.10 \
+    --filter '{"options": {"pybind": true}}' --wheel-dir wheelhouse
+xmsconan_wheel_repair --wheel-dir wheelhouse --platform windows
+xmsconan_wheel_deploy --wheel-dir wheelhouse
+```
+
+Then repeat the whole thing from a 3.13 virtual environment, into a *different* `--wheel-dir`, if you need the 3.13 wheel too.
+
+> **PowerShell mangles `--filter`.** It strips the inner double quotes, so conan sees `{options: {pybind: true}}` and the driver rejects it as invalid JSON (exit 2). Run these commands from **Git Bash**, where they work exactly as written. In PowerShell you'd have to write `--filter '{\"options\": {\"pybind\": true}}'`; using Git Bash is the supported path.
+
+**Why one run per version.** `XmsConan2File` hands CMake `Python3_EXECUTABLE = sys.executable` — the interpreter running conan — while the generated `CMakeLists.txt` requires `find_package(Python3 ${PYTHON_TARGET_VERSION} EXACT REQUIRED)`. **The recipe therefore assumes the interpreter running conan is the target Python.** CI satisfies that implicitly: `actions/setup-python` installs the matrix version and conan runs under it. A workstation doesn't — nothing installs a matching interpreter for you — so from a 3.12 venv a `--python-versions 3.10` run dies at configure with
+
+```
+Could NOT find Python3: Found unsuitable version "3.12.0",
+but required is exact version "3.10" (found .../python.exe)
+```
+
+on *every* pybind configuration, after the twelve that don't care have already built. `build` catches this before compiling anything (§16.3) and exits 2, naming the version you're running, the version(s) the matrix wants, and both ways out. From a 3.10 venv everything lines up with no recipe change: the `EXACT` check passes, the wheel comes out tagged `cp310`, and the recipe's Python test venv is 3.10 as well.
+
+**What `--wheel-dir` does.** After a clean build, per library:
+
+1. `XmsConanPackager.extract_wheel(DIR, version=<--version or '*'>)` copies each pybind package's `.whl` out of the Conan cache.
+2. `XmsConanPackager.collect_dependency_libs(DIR/libs)` gathers the shared libraries next to it — the same call, in the same place, that the generated `build.py` makes in CI. It is **not** optional on Windows: `xmsconan_wheel_repair --platform windows` passes `delvewheel repair --add-path <DIR>/libs` unconditionally, and a repair that finds nothing there yields a wheel that imports on the build box and fails everywhere else.
+
+Then it prints what is staged and what comes next:
+
+```
+==> Wheels: 1 in E:\code\xms\migration\wheelhouse: xmscore-7.0.0-cp310-cp310-win_amd64.whl
+    Next: xmsconan_wheel_repair --wheel-dir wheelhouse --platform windows, then xmsconan_wheel_deploy --wheel-dir wheelhouse
+```
+
+Points worth knowing:
+
+- **Extraction is skipped when a configuration failed.** The cache may still hold a wheel from an earlier run, and staging *that* for `xmsconan_wheel_deploy` is worse than staging none. The run already exits 1 on the failure itself.
+- **A matrix with no pybind configuration is a failure, not a no-op.** `extract_wheel` searches the whole local cache, so without that guard it would find last week's wheel and report success. If you pass `--wheel-dir`, select the pybind configurations (`--filter '{"options": {"pybind": true}}'`) or build the full matrix.
+- **A partial fan-out is a failure too.** `extract_wheel` returns False when it finds wheels for only some of the `--python-versions` entries, which is why `--python-versions 3.10` (exactly the version you're running) belongs in the command above: leaving the default `3.10 3.13` there would fail the interpreter check first, and a `--filter` narrowed to one `python_version` while `--python-versions` still lists two reports a missing wheel at the end.
+- **The summary lists the whole directory**, not just this run's copies — that directory is what repair and deploy act on next, so a wheel left over from an earlier run or a different version is about to be published too. Use a fresh `--wheel-dir` per version.
+- **`collect_dependency_libs` walks the entire Conan cache**, so on a box that is also a normal msvc 194 dev machine it stages DLLs from those packages as well. `delvewheel` only vendors libraries the wheel actually imports, but if you have same-named DLLs from both toolchains, repair from a clean cache or check the `delvewheel` output.
+- **No devpi upload path lives in this driver.** `xmsconan_wheel_deploy` is a separate command for the same reason `upload` is separate from `build` — see §13 for its credential resolution (`AQUAPI_URL` / `AQUAPI_USERNAME` / `AQUAPI_PASSWORD`, or `~/.xmsconan.toml`).
 
 ---
 
@@ -798,6 +852,9 @@ Wheels are tagged `cp310-cp310-...` or `cp313-cp313-...`; pip picks the right on
 - **VS2019 build fails on a boost option Conan says no recipe defines.** The legacy `boost/1.74.0.3` doesn't declare the conan-center 1.86 options. The driver already passes `apply_boost_defaults=False`; if you're constructing `XmsConanPackager` yourself for msvc 192, pass it too (§16.6).
 - **VS2019 packages don't show up for consumers.** They go to `aquaveo-vs2019`, not `aquaveo` — the consuming machine needs that remote configured too. Note that `xmsconan_vs2019 setup` *appends* the remote rather than putting it first (§16.2), so it does not shadow `aquaveo` for your other work.
 - **`xmsconan vs2019 build` exits 3 with a table of `skipped` rows.** Nothing was built. Almost always a typo in `--root` (each library is looked for at `<root>/<library>`), a `--filter` that matches no configuration, or a library that has no `build.toml` yet. See the exit-code table in §16.4.
+- **`Could NOT find Python3: Found unsuitable version "3.12.0", but required is exact version "3.10"`.** The interpreter running conan *is* the target Python for a pybind build (§16.8). Re-run from a 3.10 virtual environment, or build the version you're running with `--python-versions 3.12`. `xmsconan vs2019 build` now catches this at preflight and exits 2 before compiling anything — but only when the filtered matrix actually contains a pybind configuration.
+- **`--filter is not valid JSON` in PowerShell.** PowerShell strips the inner double quotes from `'{"options": {"pybind": true}}'`. Run it from Git Bash, or escape them: `'{\"options\": {\"pybind\": true}}'`.
+- **`xmsconan vs2019 build` exits 1 with "no complete set of wheels".** `--wheel-dir` was given but the run produced no wheel, or only part of the `--python-versions` fan-out. Usual causes: the matrix had no pybind configuration (add `--filter '{"options": {"pybind": true}}'`), or `--python-versions` listed a version the run never built. See §16.8.
 - **`xmsconan vs2019 upload` refuses the remote.** `--remote` is restricted to `aquaveo-vs2019`; anything else needs `--allow-other-remote` (§16.7). This is deliberate — `--remote aquaveo` would publish msvc 192 binaries into the remote every CI consumer resolves against.
 
 ---

--- a/tests/test_vs2019_build.py
+++ b/tests/test_vs2019_build.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 from unittest import mock
 
 import pytest
@@ -12,6 +13,21 @@ from .utils import patch_env
 
 
 MODULE = "xmsconan.build_tools.vs2019_build"
+
+#: The interpreter this suite is running under -- which, for a pybind build,
+#: is also the only Python version the recipe can target.
+RUNNING_PYTHON = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+#: A Python version no test runner will ever be running, so a mismatch is
+#: guaranteed without patching the interpreter out from under the check.
+FOREIGN_PYTHON = "3.7"
+
+#: A passing interpreter check, for the CLI tests that are not about it.
+PYTHON_CHECK_OK = vs.CheckResult("python interpreter", True, "ok")
+
+#: The specs the loop in build() hands to build_library.
+XMSCORE = vs.LibrarySpec("xmscore", True)
+XMSGRID = vs.LibrarySpec("xmsgrid", False)
 
 
 def fake_packager(configurations=None, run_result=0):
@@ -393,6 +409,50 @@ def test_run_preflight_prints_each_check(capsys):
     assert "[FAIL] conan: too new" in out
 
 
+# --- the running interpreter vs. the pybind matrix ----------------------
+
+
+@pytest.mark.parametrize("python_versions,config_filter,ok,expected", [
+    ([FOREIGN_PYTHON], None, False, [
+        f"pybind configurations for Python {FOREIGN_PYTHON}",
+        f"running under Python {RUNNING_PYTHON}",
+        f"re-run from a Python {FOREIGN_PYTHON} environment",
+        f"--python-versions {RUNNING_PYTHON}",
+    ]),
+    ([RUNNING_PYTHON], None, True, [f"Python {RUNNING_PYTHON}, matching"]),
+    ([FOREIGN_PYTHON, RUNNING_PYTHON], None, False,
+     [f"Python {FOREIGN_PYTHON}, {RUNNING_PYTHON}"]),
+    ([FOREIGN_PYTHON], {"options": {"pybind": False}}, True,
+     ["no pybind configuration"]),
+], ids=[
+    "mismatched-interpreter", "matching-interpreter",
+    "one-version-of-the-fan-out-matches", "pybind-free-matrix",
+])
+def test_check_python_versions(python_versions, config_filter, ok, expected):
+    """Only a matrix that really builds pybind constrains the interpreter.
+
+    The recipe hands CMake ``sys.executable`` while the generated
+    CMakeLists.txt requires ``find_package(Python3 <version> EXACT)``, so the
+    interpreter running conan is the target Python whether the developer meant
+    it to be or not. CI never notices -- ``actions/setup-python`` installs the
+    matrix version and conan runs under it -- so the failure only ever shows
+    up on a workstation, hours in, at the first pybind configure.
+
+    Run against the real packager and the real filter, because the whole
+    question is what the *generated and filtered* matrix contains: 12 of the
+    14 configurations have ``pybind=False`` and are indifferent to the running
+    interpreter. And "some of the fan-out matches" is still a failure -- the
+    3.13 half of a default two-version run fails just as hard from a 3.10
+    venv.
+    """
+    check = vs.check_python_versions(
+        [XMSCORE], python_versions=python_versions, config_filter=config_filter,
+    )
+
+    assert check.ok is ok
+    assert all(text in check.detail for text in expected)
+
+
 # --- setup ---------------------------------------------------------------
 
 
@@ -497,11 +557,6 @@ def test_preview_applies_filter(capsys):
 # --- build_library -------------------------------------------------------
 
 
-#: The spec the loop in build() hands to build_library.
-XMSCORE = vs.LibrarySpec("xmscore", True)
-XMSGRID = vs.LibrarySpec("xmsgrid", False)
-
-
 def test_build_library_missing_checkout(tmp_path):
     """A missing library directory is skipped, not fatal."""
     result = vs.build_library(XMSGRID, str(tmp_path))
@@ -599,6 +654,121 @@ def test_build_library_filter_matches_nothing(mock_run, mock_packager_cls, libra
     packager.run.assert_not_called()
     assert result.status == "skipped"
     assert "no configurations matched" in result.message
+
+
+# --- wheels --------------------------------------------------------------
+
+
+#: What the packager hands back for a pybind and a non-pybind configuration.
+PYBIND_CONFIG = {"options": {"pybind": True, "python_version": "3.10"}}
+PLAIN_CONFIG = {"options": {"pybind": False}}
+
+
+@pytest.mark.parametrize("configurations,extracted,version,expected,calls", [
+    ([PLAIN_CONFIG], True, "7.0.0", False, 0),
+    ([PLAIN_CONFIG, PYBIND_CONFIG], False, None, False, 1),
+    ([PLAIN_CONFIG, PYBIND_CONFIG], True, "7.0.0", True, 1),
+], ids=["no-pybind-configuration", "incomplete-fan-out", "extracted"])
+def test_extract_wheels(configurations, extracted, version, expected, calls, capsys):
+    """A wheel is only claimed when this run built one for every version asked for.
+
+    Three things have to hold, and each one is a way to publish the wrong
+    thing to devpi:
+
+    * ``extract_wheel`` searches the whole local cache, so a matrix with no
+      pybind configuration must not call it at all -- it would find last
+      week's wheel and report success.
+    * Its False return covers a *partial* fan-out (wheels for some
+      ``--python-versions`` entries but not all), which this driver can cause
+      because it owns that flag, so the result is propagated rather than
+      reduced to "something was copied".
+    * ``collect_dependency_libs`` only runs once there is a wheel to repair,
+      and fills the ``libs`` directory that ``xmsconan_wheel_repair --platform
+      windows`` passes to ``delvewheel --add-path`` unconditionally.
+    """
+    packager = fake_packager()
+    packager.extract_wheel.return_value = extracted
+
+    assert vs.extract_wheels(packager, configurations, "wheelhouse", version) is expected
+
+    assert packager.extract_wheel.call_count == calls
+    if calls:
+        # a --version of None must not become the literal string "None"
+        assert packager.extract_wheel.call_args == mock.call(
+            "wheelhouse", version=version or "*",
+        )
+    else:
+        assert "no pybind configuration was built" in capsys.readouterr().out
+    if expected:
+        packager.collect_dependency_libs.assert_called_once_with(
+            os.path.join("wheelhouse", "libs")
+        )
+    else:
+        packager.collect_dependency_libs.assert_not_called()
+
+
+@pytest.mark.parametrize("wheel_dir,run_result,extracted,expected", [
+    ("wheelhouse", 0, True, True),
+    ("wheelhouse", 0, False, False),
+    (None, 0, True, None),
+    ("wheelhouse", 1, True, None),
+], ids=["extracted", "extraction-failed", "no-wheel-dir", "build-failed"])
+@mock.patch(f"{MODULE}.XmsConanPackager")
+@mock.patch(f"{MODULE}.subprocess.run")
+def test_build_library_extracts_wheels(mock_run, mock_packager_cls, wheel_dir,
+                                       run_result, extracted, expected, library_root):
+    """--wheel-dir extracts after a clean build, and only after a clean build.
+
+    A failed configuration leaves the extraction alone on purpose: the cache
+    may still hold a wheel from an earlier run, and staging *that* for
+    ``xmsconan_wheel_deploy`` is worse than staging nothing. The run already
+    exits 1 on the failure itself.
+    """
+    packager = fake_packager(configurations=[PYBIND_CONFIG], run_result=run_result)
+    mock_packager_cls.return_value = packager
+
+    with mock.patch(f"{MODULE}.extract_wheels", return_value=extracted) as extract:
+        result = vs.build_library(
+            XMSCORE, str(library_root), version="7.0.0", wheel_dir=wheel_dir,
+        )
+
+    assert result.wheels is expected
+    assert extract.called is (expected is not None)
+
+
+@pytest.mark.parametrize("wheels,expected_code,expected_out", [
+    (True, 0, ["==> Wheels: 1 in", "xmscore-7.0.0-cp310-cp310-win_amd64.whl",
+               "xmsconan_wheel_repair", "xmsconan_wheel_deploy"]),
+    (False, 1, ["==> Wheels: none in"]),
+], ids=["staged", "nothing-extracted"])
+def test_print_summary_reports_the_wheel_directory(wheels, expected_code, expected_out,
+                                                   tmp_path, capsys):
+    """A build asked for a wheel that produced none has not done what was asked.
+
+    That is a build failure (exit 1), not a new exit code: the run was asked
+    for an artifact, it ran, and the artifact is not there -- and the
+    ``xmsconan_wheel_repair`` the developer runs next would be handed an empty
+    directory. The listing covers the whole directory rather than just this
+    run's copies, because the whole directory is what repair and deploy act
+    on: a wheel left behind by an earlier run is about to be published too.
+    """
+    wheel_dir = tmp_path / "wheelhouse"
+    if wheels:
+        wheel_dir.mkdir()
+        (wheel_dir / "xmscore-7.0.0-cp310-cp310-win_amd64.whl").write_text("", encoding="utf-8")
+        # the staged dependency libraries are not wheels and must not be listed
+        (wheel_dir / "libs").mkdir()
+        (wheel_dir / "boost_thread.dll").write_text("", encoding="utf-8")
+
+    exit_code = vs.print_summary(
+        [vs.LibraryResult("xmscore", "ok", attempted=2, succeeded=2, wheels=wheels)],
+        wheel_dir=str(wheel_dir),
+    )
+
+    assert exit_code == expected_code
+    captured = capsys.readouterr()
+    assert all(text in captured.out for text in expected_out)
+    assert ("no complete set of wheels" in captured.err) is not wheels
 
 
 # --- build ---------------------------------------------------------------
@@ -847,9 +1017,10 @@ UPLOAD_ARGV = ["upload", "--library", "xmscore", "--version", "7.0.0"]
     "setup-conan-not-on-path", "setup-bad-password-file", "setup-conan-exit-code",
     "build-generator-not-on-path", "upload-conan-not-on-path", "upload-refused-remote",
 ])
+@mock.patch(f"{MODULE}.check_python_versions", return_value=PYTHON_CHECK_OK)
 @mock.patch(f"{MODULE}.run_preflight", return_value=[vs.CheckResult("vs", True, "ok")])
-def test_main_reports_a_failing_verb(mock_preflight, verb, exception, argv, exit_code,
-                                     message, capsys):
+def test_main_reports_a_failing_verb(mock_preflight, mock_python_check, verb, exception,
+                                     argv, exit_code, message, capsys):
     """Every subcommand turns a failure into a message on stderr, not a traceback.
 
     An executable that will not start and a bad request are both "exit 2" by
@@ -862,10 +1033,12 @@ def test_main_reports_a_failing_verb(mock_preflight, verb, exception, argv, exit
     assert message in capsys.readouterr().err
 
 
+@mock.patch(f"{MODULE}.check_python_versions", return_value=PYTHON_CHECK_OK)
 @mock.patch(f"{MODULE}.run_preflight", return_value=[vs.CheckResult("vs", True, "ok")])
 @mock.patch(f"{MODULE}.build",
             side_effect=PermissionError("[Errno 13] Permission denied: 'profile.txt'"))
-def test_main_build_reports_an_io_error_for_what_it_is(mock_build, mock_preflight, capsys):
+def test_main_build_reports_an_io_error_for_what_it_is(mock_build, mock_preflight,
+                                                       mock_python_check, capsys):
     """A disk or permission fault is reported verbatim, not blamed on PATH.
 
     Writing a build profile and reading the VS toolset marker both raise
@@ -925,15 +1098,18 @@ def test_main_build_preflight_failure(mock_preflight, capsys):
     assert "preflight failed" in capsys.readouterr().err
 
 
+@mock.patch(f"{MODULE}.check_python_versions", return_value=PYTHON_CHECK_OK)
 @mock.patch(f"{MODULE}.build",
             return_value=[vs.LibraryResult("xmscore", "ok", attempted=14, succeeded=14)])
 @mock.patch(f"{MODULE}.run_preflight", return_value=[vs.CheckResult("vs", True, "ok")])
-def test_main_build_passes_every_flag(mock_preflight, mock_build, tmp_path):
+def test_main_build_passes_every_flag(mock_preflight, mock_build, mock_python_check,
+                                      tmp_path, capsys):
     """Each build flag reaches build() and the summary sets the exit code."""
     exit_code = run_main([
         "build", "--root", str(tmp_path), "--only", "xmscore",
         "--continue-on-error", "--no-generate", "--log-dir", "logs",
         "--python-versions", "3.13", "--version", "7.0.0",
+        "--wheel-dir", str(tmp_path / "wheelhouse"),
     ])
 
     assert exit_code == 0
@@ -942,15 +1118,21 @@ def test_main_build_passes_every_flag(mock_preflight, mock_build, tmp_path):
     assert args[1] == str(tmp_path)
     assert kwargs == {
         "version": "7.0.0", "generate": False, "python_versions": ["3.13"],
-        "config_filter": None, "log_dir": "logs", "continue_on_error": True,
+        "config_filter": None, "log_dir": "logs",
+        "wheel_dir": str(tmp_path / "wheelhouse"), "continue_on_error": True,
     }
     mock_preflight.assert_called_once_with(remote=vs.VS2019_REMOTE_NAME)
+    # --wheel-dir has to reach the summary too, or a run that extracted
+    # nothing would still exit 0
+    assert "==> Wheels: none" in capsys.readouterr().out
 
 
+@mock.patch(f"{MODULE}.check_python_versions", return_value=PYTHON_CHECK_OK)
 @mock.patch(f"{MODULE}.build",
             return_value=[vs.LibraryResult("xmscore", "ok", attempted=14, succeeded=14)])
 @mock.patch(f"{MODULE}.run_preflight", return_value=[vs.CheckResult("vs", True, "ok")])
-def test_main_build_remote_name_reaches_preflight(mock_preflight, mock_build, tmp_path):
+def test_main_build_remote_name_reaches_preflight(mock_preflight, mock_build,
+                                                  mock_python_check, tmp_path):
     """--remote-name redirects the preflight check, matching setup's flag.
 
     ``setup --remote-name scratch`` is a supported way to point a machine at
@@ -964,12 +1146,43 @@ def test_main_build_remote_name_reaches_preflight(mock_preflight, mock_build, tm
     mock_preflight.assert_called_once_with(remote="scratch")
 
 
+@mock.patch(f"{MODULE}.check_python_versions", return_value=PYTHON_CHECK_OK)
 @mock.patch(f"{MODULE}.build",
             return_value=[vs.LibraryResult("xmscore", "failed", attempted=14, failed=1)])
 @mock.patch(f"{MODULE}.run_preflight", return_value=[vs.CheckResult("vs", True, "ok")])
-def test_main_build_failure_exit_code(mock_preflight, mock_build):
+def test_main_build_failure_exit_code(mock_preflight, mock_build, mock_python_check):
     """A failed configuration makes the whole run exit nonzero."""
     assert run_main(["build"]) == 1
+
+
+@pytest.mark.parametrize("extra_argv,exit_code,build_ran", [
+    ([], 2, False),
+    (["--filter", '{"options": {"pybind": false}}'], 0, True),
+], ids=["pybind-matrix-is-refused", "pybind-free-matrix-proceeds"])
+@mock.patch(f"{MODULE}.build",
+            return_value=[vs.LibraryResult("xmscore", "ok", attempted=12, succeeded=12)])
+@mock.patch(f"{MODULE}.run_preflight", return_value=[vs.CheckResult("vs", True, "ok")])
+def test_main_build_checks_the_interpreter_against_the_real_matrix(
+        mock_preflight, mock_build, extra_argv, exit_code, build_ran, tmp_path, capsys):
+    """The interpreter check is scoped to matrices that actually build pybind.
+
+    Twelve of the fourteen configurations never touch Python, so a developer
+    building only those from whatever virtualenv they happen to be in has to
+    keep working -- which is why this runs against the *generated and
+    filtered* matrix rather than the flag values. Both directions are the
+    point: the same mismatched ``--python-versions`` fails a pybind matrix
+    before a single ``conan create`` and passes a pybind-free one.
+    """
+    assert run_main([
+        "build", "--root", str(tmp_path),
+        "--python-versions", FOREIGN_PYTHON,
+    ] + extra_argv) == exit_code
+
+    assert mock_build.called is build_ran
+    captured = capsys.readouterr()
+    if not build_ran:
+        assert f"conan is running under Python {RUNNING_PYTHON}" in captured.out
+        assert "preflight failed" in captured.err
 
 
 @mock.patch(f"{MODULE}.upload", return_value=0)

--- a/xmsconan/build_tools/vs2019_build.py
+++ b/xmsconan/build_tools/vs2019_build.py
@@ -16,11 +16,40 @@ Three subcommands::
 build must never push binaries to a shared remote as a side effect, so a
 human looks at the build result before running ``upload``.
 
+Python wheels follow the same split.  ``build --wheel-dir DIR`` copies each
+pybind package's ``.whl`` out of the Conan cache and stages the shared
+libraries the repair step needs; *repairing* and *publishing* stay separate
+commands, exactly as ``upload`` is separate from ``build`` and for the same
+reason::
+
+    # from a Python 3.10 virtual environment
+    xmsconan_vs2019 build --root E:\code\xms\migration --version 7.0.0 \
+        --python-versions 3.10 --filter '{"options": {"pybind": true}}' \
+        --wheel-dir wheelhouse
+    xmsconan_wheel_repair --wheel-dir wheelhouse --platform windows
+    xmsconan_wheel_deploy --wheel-dir wheelhouse
+
+**One run per Python version, from an interpreter of that version.**
+:class:`~xmsconan.xms_conan2_file.XmsConan2File` points CMake at
+``sys.executable`` -- the interpreter running conan -- while the generated
+``CMakeLists.txt`` requires ``find_package(Python3 ${PYTHON_TARGET_VERSION}
+EXACT REQUIRED)``.  CI satisfies that implicitly, because
+``actions/setup-python`` installs the matrix version and conan runs under it;
+a workstation does not, so a 3.12 virtualenv building
+``--python-versions 3.10`` fails every pybind configuration at configure
+time.  :func:`check_python_versions` catches that before anything is
+compiled, and only when the *filtered* matrix actually contains a pybind
+configuration -- the other twelve configurations do not care which
+interpreter is running.
+
 Process exit codes are the contract with whatever wrapper script drives
 this, so they are distinct:
 
 * ``0`` -- everything asked for happened.
-* ``1`` -- a library failed to build, or ``conan upload`` failed.
+* ``1`` -- a library failed to build, ``conan upload`` failed, or a
+  ``--wheel-dir`` run produced no wheel.  A missing wheel is a build failure
+  rather than a code of its own: the run was asked for an artifact, it ran,
+  and the artifact is not there.
 * ``2`` -- the request or the machine was wrong: a bad flag, a ``--root``
   that does not exist, a selection that matches no library, a failed
   preflight (from either ``setup`` or ``build`` -- the same condition gets
@@ -185,6 +214,13 @@ class LibraryResult:
         failed: Configurations that failed.
         elapsed: Wall-clock seconds spent on this library.
         message: Why it was skipped, or what went wrong.
+        wheels: True when ``--wheel-dir`` was given and a wheel was extracted
+            for every requested Python version, False when the extraction
+            produced nothing or only part of the fan-out, and None when no
+            wheel was asked for -- or when the library never got that far
+            (skipped, or a configuration failed).  None therefore never means
+            "a wheel is missing"; those runs already exit nonzero on their own
+            status.
     """
 
     name: str
@@ -194,6 +230,7 @@ class LibraryResult:
     failed: int = 0
     elapsed: float = 0.0
     message: str = ""
+    wheels: Optional[bool] = None
 
 
 # --- library selection ---------------------------------------------------
@@ -497,8 +534,27 @@ def check_remote_configured(remote=VS2019_REMOTE_NAME):
     return CheckResult(name, True, "configured")
 
 
+def print_check(check):
+    """Print one check result in the preflight's OK/FAIL format.
+
+    Args:
+        check: The :class:`CheckResult` to print.
+
+    Returns:
+        ``check``, so a caller can print and collect in one expression.
+    """
+    print(f"  [{'OK' if check.ok else 'FAIL'}] {check.name}: {check.detail}")
+    return check
+
+
 def run_preflight(remote=VS2019_REMOTE_NAME):
-    """Run every preflight check and print the results.
+    """Run every *machine* preflight check and print the results.
+
+    Only checks that need nothing but the machine live here, because this
+    runs from ``setup`` too, where there is no build request to check against.
+    The one check that does need the request -- the running interpreter versus
+    the pybind configurations, :func:`check_python_versions` -- is run by
+    ``build`` afterwards and printed into the same block.
 
     Args:
         remote: Remote name the build publishes to.
@@ -513,7 +569,7 @@ def run_preflight(remote=VS2019_REMOTE_NAME):
         check_remote_configured(remote),
     ]
     for check in checks:
-        print(f"  [{'OK' if check.ok else 'FAIL'}] {check.name}: {check.detail}")
+        print_check(check)
     return checks
 
 
@@ -612,6 +668,87 @@ def _configure(packager, config_filter):
     return packager.configurations
 
 
+def _pybind_python_versions(configurations):
+    """Return the ``python_version`` values of the pybind configurations.
+
+    Every pybind configuration carries a ``"X.Y"`` ``python_version`` -- the
+    packager sets it as it fans the variants out -- so the sort is numeric
+    rather than lexicographic; ``"3.7"`` sorts after ``"3.13"`` as a string.
+
+    Args:
+        configurations: A generated (and filtered) configuration list.
+
+    Returns:
+        Sorted list of ``"X.Y"`` strings; empty when nothing in
+        ``configurations`` builds pybind.
+    """
+    versions = {
+        configuration.get("options", {}).get("python_version")
+        for configuration in configurations
+        if configuration.get("options", {}).get("pybind")
+    }
+    return sorted(versions, key=lambda v: tuple(int(part) for part in v.split(".")))
+
+
+def check_python_versions(libraries, python_versions=None, config_filter=None):
+    """Check the interpreter running conan against the pybind configurations.
+
+    The recipe hands CMake ``Python3_EXECUTABLE = sys.executable`` while the
+    generated ``CMakeLists.txt`` requires ``find_package(Python3
+    ${PYTHON_TARGET_VERSION} EXACT REQUIRED)``, so the interpreter running
+    conan *is* the target Python.  CI gets that for free from
+    ``actions/setup-python``; on a workstation the developer supplies it, and
+    a mismatch fails every pybind configuration at configure time -- an hour
+    or two in, after the twelve configurations that do not care have built.
+
+    This is deliberately not one of the :func:`run_preflight` checks.  It has
+    to see the *generated and filtered* matrix: twelve of the fourteen
+    configurations have ``pybind=False`` and are indifferent to the running
+    interpreter, and ``--filter`` can remove the pybind pair outright, so
+    checking the flag values alone would fail builds that work today.  The
+    matrix is a function of the platform key, ``python_versions`` and
+    ``config_filter`` -- not of the library -- so generating it once for the
+    first selected library answers for the whole run.
+
+    Args:
+        libraries: :class:`LibrarySpec` list from :func:`select_libraries`;
+            must not be empty (the caller rejects an empty selection first).
+        python_versions: Python versions for the pybind variants.
+        config_filter: Filter dict for ``filter_configurations``, or None.
+
+    Returns:
+        A :class:`CheckResult`.  ``ok`` is True when the filtered matrix has
+        no pybind configuration at all, or when every pybind configuration
+        targets the running version.
+
+    Raises:
+        ValueError: When ``python_versions`` holds an entry the packager
+            rejects, or ``config_filter`` names an unknown key.
+    """
+    name = "python interpreter"
+    running = f"{sys.version_info.major}.{sys.version_info.minor}"
+    packager = _new_packager(libraries[0].name, ".", python_versions)
+    requested = _pybind_python_versions(_configure(packager, config_filter))
+    if not requested:
+        return CheckResult(
+            name, True, f"Python {running} (no pybind configuration in this matrix)",
+        )
+    if requested == [running]:
+        return CheckResult(name, True, f"Python {running}, matching the pybind matrix")
+    return CheckResult(
+        name, False,
+        f"this run would build pybind configurations for Python "
+        f"{', '.join(requested)}, but conan is running under Python {running} "
+        f"({sys.executable}). The recipe points CMake at the interpreter "
+        f"running conan and the generated CMakeLists.txt requires that exact "
+        f"version, so every pybind configuration would fail at configure time. "
+        f"Either re-run from a Python {requested[0]} environment (a virtualenv "
+        f"of that version with conan and xmsconan installed), or pass "
+        f"--python-versions {running} to build for the interpreter you are "
+        f"already running.",
+    )
+
+
 def preview(libraries, python_versions=None, config_filter=None):
     """Print the configuration matrix for each library without building.
 
@@ -631,8 +768,53 @@ def preview(libraries, python_versions=None, config_filter=None):
     return 0
 
 
+def extract_wheels(packager, configurations, wheel_dir, version=None):
+    """Copy the pybind wheels out of the Conan cache and stage the repair libs.
+
+    Both halves are what the generated ``build.py`` does in CI, in the same
+    order and for the same reasons:
+
+    * ``extract_wheel`` returns False on a *partial* fan-out -- wheels found
+      for some ``--python-versions`` entries but not all -- so its result is
+      propagated rather than reduced to "something was copied".  This driver
+      controls ``--python-versions``, so a partial result means the developer
+      asked for two wheels and is about to publish one.
+    * ``collect_dependency_libs`` fills ``<wheel_dir>/libs``, which is not
+      optional on Windows: ``xmsconan_wheel_repair --platform windows`` hands
+      ``delvewheel repair --add-path <wheel_dir>/libs`` unconditionally, and a
+      repair that finds nothing there produces a wheel that imports on the
+      build box and fails everywhere else.
+
+    An empty pybind set short-circuits: ``extract_wheel`` searches the whole
+    local cache, so on a machine that built a wheel last week it would happily
+    copy *that* wheel out and report success for a matrix that never built one.
+
+    Args:
+        packager: The :class:`~xmsconan.package_tools.packager.XmsConanPackager`
+            that just ran; it carries the ``python_versions`` the fan-out is
+            checked against.
+        configurations: The configurations that were built.
+        wheel_dir: Directory to copy the ``.whl`` files into.
+        version: Package version, or None to match any version in the cache.
+
+    Returns:
+        True when a wheel was extracted for every requested Python version.
+    """
+    if not _pybind_python_versions(configurations):
+        print(
+            f"==> no pybind configuration was built, so there is no wheel to "
+            f"extract into {wheel_dir}"
+        )
+        return False
+    if not packager.extract_wheel(wheel_dir, version=version or "*"):
+        return False
+    packager.collect_dependency_libs(os.path.join(wheel_dir, "libs"))
+    return True
+
+
 def build_library(library: LibrarySpec, root, version=None, generate=True,
-                  python_versions=None, config_filter=None, log_dir=None):
+                  python_versions=None, config_filter=None, log_dir=None,
+                  wheel_dir=None):
     """Generate build files for one library and build the VS2019 matrix.
 
     A missing checkout or ``build.toml`` is reported and skipped rather than
@@ -649,6 +831,11 @@ def build_library(library: LibrarySpec, root, version=None, generate=True,
         python_versions: Python versions for the pybind variants.
         config_filter: Filter dict for ``filter_configurations``, or None.
         log_dir: Directory for per-configuration ``conan create`` logs.
+        wheel_dir: Directory to extract the pybind wheels into, or None to
+            skip wheel handling entirely.  Extraction is skipped when any
+            configuration failed: the cache may still hold a wheel from an
+            earlier run, and staging *that* for ``xmsconan_wheel_deploy`` is
+            worse than staging none.
 
     Returns:
         A :class:`LibraryResult`.
@@ -698,6 +885,9 @@ def build_library(library: LibrarySpec, root, version=None, generate=True,
         )
     print(f"==> {name}: building {attempted} configuration(s)")
     failed = packager.run(log_dir=log_dir)
+    wheels = None
+    if wheel_dir and not failed:
+        wheels = extract_wheels(packager, configurations, wheel_dir, version)
     return LibraryResult(
         name,
         "failed" if failed else "ok",
@@ -705,11 +895,13 @@ def build_library(library: LibrarySpec, root, version=None, generate=True,
         succeeded=attempted - failed,
         failed=failed,
         elapsed=time.monotonic() - start,
+        wheels=wheels,
     )
 
 
 def build(libraries, root, version=None, generate=True, python_versions=None,
-          config_filter=None, log_dir=None, continue_on_error=False):
+          config_filter=None, log_dir=None, wheel_dir=None,
+          continue_on_error=False):
     """Build every selected library in dependency order.
 
     ``packager.run()`` already continues past an individual failing
@@ -726,6 +918,7 @@ def build(libraries, root, version=None, generate=True, python_versions=None,
         python_versions: Python versions for the pybind variants.
         config_filter: Filter dict for ``filter_configurations``, or None.
         log_dir: Directory for per-configuration ``conan create`` logs.
+        wheel_dir: Directory to extract the pybind wheels into, or None.
         continue_on_error: Keep going to the next library after a failure.
 
     Returns:
@@ -738,7 +931,7 @@ def build(libraries, root, version=None, generate=True, python_versions=None,
         results.append(build_library(
             library, root, version=version, generate=generate,
             python_versions=python_versions, config_filter=config_filter,
-            log_dir=log_dir,
+            log_dir=log_dir, wheel_dir=wheel_dir,
         ))
         if results[-1].status == "failed" and not continue_on_error:
             print(
@@ -749,18 +942,83 @@ def build(libraries, root, version=None, generate=True, python_versions=None,
     return results
 
 
-def print_summary(results):
+def _wheel_files(wheel_dir):
+    """Return the sorted ``.whl`` filenames in ``wheel_dir``.
+
+    Args:
+        wheel_dir: Directory the wheels were extracted into.  A directory that
+            was never created is the ordinary "nothing was extracted" case, so
+            it yields an empty list rather than raising.
+
+    Returns:
+        Sorted list of filenames.
+    """
+    if not os.path.isdir(wheel_dir):
+        return []
+    return sorted(name for name in os.listdir(wheel_dir) if name.endswith(".whl"))
+
+
+def print_wheel_summary(results, wheel_dir):
+    """Print what is staged in ``wheel_dir`` and whether anything is missing.
+
+    Everything in the directory is listed, not just what this run copied in:
+    the whole directory is what ``xmsconan_wheel_repair`` and
+    ``xmsconan_wheel_deploy`` act on next, so a wheel left over from an
+    earlier run or a different version is about to be published too.
+
+    Args:
+        results: :class:`LibraryResult` list from :func:`build`.
+        wheel_dir: Directory the wheels were extracted into.
+
+    Returns:
+        True when every library that got as far as extraction produced a
+        wheel for every requested Python version.
+    """
+    wheels = _wheel_files(wheel_dir)
+    location = os.path.abspath(wheel_dir)
+    if wheels:
+        print(f"\n==> Wheels: {len(wheels)} in {location}: {', '.join(wheels)}")
+        print(
+            f"    Next: xmsconan_wheel_repair --wheel-dir {wheel_dir} "
+            f"--platform windows, then xmsconan_wheel_deploy --wheel-dir "
+            f"{wheel_dir}"
+        )
+    else:
+        print(f"\n==> Wheels: none in {location}")
+    missing = [result.name for result in results if result.wheels is False]
+    if missing:
+        print(
+            f"error: --wheel-dir was given but no complete set of wheels came "
+            f"out of {', '.join(missing)}. Either the matrix built no pybind "
+            f"configuration -- select it with --filter "
+            f"'{{\"options\": {{\"pybind\": true}}}}' -- or only part of the "
+            f"--python-versions fan-out produced one; pass exactly the version "
+            f"this interpreter is running.",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def print_summary(results, wheel_dir=None):
     """Print the per-library summary table and return the exit code.
 
     Args:
         results: :class:`LibraryResult` list from :func:`build`.
+        wheel_dir: Directory wheels were extracted into, or None when
+            ``--wheel-dir`` was not passed.
 
     Returns:
         Process exit code: 1 when any library failed, 3 when the run finished
-        without a single library reaching ``'ok'``, 0 otherwise.  "Nothing
-        happened" is not success -- a typo'd ``--root`` skips every library,
-        and an ``&&`` chain or wrapper script reading exit 0 would go on to
-        upload or tag a release that was never built.
+        without a single library reaching ``'ok'``, 1 again when a wheel was
+        asked for and none was produced, 0 otherwise.  "Nothing happened" is
+        not success -- a typo'd ``--root`` skips every library, and an ``&&``
+        chain or wrapper script reading exit 0 would go on to upload or tag a
+        release that was never built.  A missing wheel is the same kind of
+        event as a failed configuration -- the run was asked for an artifact
+        and did not produce it -- so it reuses code 1 rather than inventing a
+        fourth; the following ``xmsconan_wheel_repair`` would otherwise be
+        handed an empty directory.
     """
     rows = [
         [r.name, r.status, r.attempted, r.succeeded, r.failed,
@@ -774,6 +1032,7 @@ def print_summary(results):
                  "elapsed", "notes"],
         tablefmt="psql",
     ))
+    wheels_ok = print_wheel_summary(results, wheel_dir) if wheel_dir else True
     if any(r.status == "failed" for r in results):
         return 1
     if not any(r.status == "ok" for r in results):
@@ -783,7 +1042,7 @@ def print_summary(results):
             file=sys.stderr,
         )
         return EXIT_NOTHING_BUILT
-    return 0
+    return 0 if wheels_ok else 1
 
 
 # --- upload --------------------------------------------------------------
@@ -945,7 +1204,17 @@ def _add_build_parser(subparsers):
         "--python-versions", nargs="+", metavar="X.Y",
         default=DEFAULT_PYTHON_VERSIONS,
         help=f"Python versions for the pybind variants (default: "
-             f"{' '.join(DEFAULT_PYTHON_VERSIONS)}).",
+             f"{' '.join(DEFAULT_PYTHON_VERSIONS)}). A pybind build only works "
+             f"when this matches the Python running conan, so build wheels one "
+             f"version per run, from a virtual environment of that version.",
+    )
+    build_parser.add_argument(
+        "--wheel-dir", default=None, metavar="DIR",
+        help="After the build, copy each pybind package's .whl into DIR and "
+             "fill DIR/libs with the shared libraries the repair step needs. "
+             "Repairing and publishing stay separate commands: "
+             "xmsconan_wheel_repair --wheel-dir DIR --platform windows, then "
+             "xmsconan_wheel_deploy --wheel-dir DIR.",
     )
     build_parser.add_argument(
         "--filter", default=None, dest="config_filter",
@@ -1088,7 +1357,16 @@ def _run_build(args):
                 file=sys.stderr,
             )
             return EXIT_USAGE
-        if not all(check.ok for check in run_preflight(remote=args.remote_name)):
+        # The interpreter check runs after the matrix exists and --filter has
+        # been applied -- the answer depends on what is actually going to be
+        # built, not on the flag values -- and prints into the same block.
+        checks = run_preflight(remote=args.remote_name) + [print_check(
+            check_python_versions(
+                libraries, python_versions=args.python_versions,
+                config_filter=config_filter,
+            )
+        )]
+        if not all(check.ok for check in checks):
             print(
                 "error: preflight failed; fix the items above and re-run.",
                 file=sys.stderr,
@@ -1098,9 +1376,9 @@ def _run_build(args):
             libraries, args.root, version=args.version,
             generate=not args.no_generate, python_versions=args.python_versions,
             config_filter=config_filter, log_dir=args.log_dir,
-            continue_on_error=args.continue_on_error,
+            wheel_dir=args.wheel_dir, continue_on_error=args.continue_on_error,
         )
-        return print_summary(results)
+        return print_summary(results, wheel_dir=args.wheel_dir)
     except ValueError as exc:
         # Bad --only / --from / --filter, or a malformed --python-versions
         # entry rejected by the packager.


### PR DESCRIPTION
Stacked on #86 — review that one first; this PR's diff is only the wheel work.

The VS2019 driver could build pybind packages but had **no way to get the wheel out**, so msvc 192 wheels could not reach devpi. The machinery already existed in the packager and in CI's generated `build.py`; this wires it into the driver and adds the check that makes the local workflow usable.

## `--wheel-dir` on `build`

Copies each pybind package's `.whl` into the directory and fills `DIR/libs` via `collect_dependency_libs`, mirroring the generated `build.py`. Repair and publish stay separate commands — same reasoning as `build` and `upload` being separate verbs.

```bash
# from a Python 3.10 virtual environment with conan + xmsconan installed
xmsconan vs2019 build --root <root> --version 7.0.0 --python-versions 3.10 \
    --filter '{"options": {"pybind": true}}' --wheel-dir wheelhouse
xmsconan_wheel_repair --wheel-dir wheelhouse --platform windows
xmsconan_wheel_deploy --wheel-dir wheelhouse
```

**Two guards CI does not need**, because CI runs on a clean runner and this runs on a mixed workstation: extraction is skipped when the matrix holds no pybind configuration, and when any configuration failed. `extract_wheel` scans the *whole local cache*, so without them a run that built nothing could copy out a stale wheel from last week and report success.

## The one-run-per-Python-version constraint

A preflight check now rejects a `--python-versions` value that does not match the interpreter running conan.

`XmsConan2File._get_python_cmake_hints()` passes `sys.executable` as `Python3_EXECUTABLE`, while the generated `CMakeLists.txt` requires `find_package(Python3 ${PYTHON_TARGET_VERSION} EXACT REQUIRED)`. So **the recipe assumes the interpreter running conan is the target Python.** CI satisfies that implicitly through `actions/setup-python`; a workstation must supply it. Without the check you discover this ~90 seconds in:

```
Could NOT find Python3: Found unsuitable version "3.12.0",
but required is exact version "3.10"
```

**This PR deliberately does not change the recipe.** That path works correctly in CI for gcc, apple-clang and msvc 194 across both Python versions, and is not worth risking to fix a workstation-only ergonomic problem. The fix is to reproduce locally what CI does: one run per Python version, from an environment of that version.

**Where the check lives matters.** It runs after the matrix is generated and filtered, *not* in `run_preflight` — that is shared with `setup`, where no matrix exists. And 12 of the 14 configurations have `pybind=False` and do not care what Python is running, so building only those from a mismatched interpreter still works. `--preview` returns before the check, so previewing a mismatched matrix still works too. Both directions are tested.

## Exit codes

A `--wheel-dir` run that produces no complete set of wheels exits **1** rather than a new code: the run was asked for an artifact, it ran, and the artifact is not there. `extract_wheel`'s partial-fan-out result propagates, so "wheels for 3.10 but not 3.13" fails rather than silently shipping half.

## Verified end to end on a real workstation

Not just unit-tested. From a Python 3.10.2 environment, `xmscore` built for msvc 192:

- CMake selected the 3.10 interpreter — `Found Python3: ...\.venv310\Scripts\python.exe (found suitable exact version`
- linked `boost/1.74.0.3#581888bc…:3e85d203…`, the **builtin**-`wchar_t` package, correct for a pybind build
- **25 Python tests collected, 25 passed** in a 3.10 test environment
- produced `xmscore-7.0.0-cp310-cp310-win_amd64.whl`, `Tag: cp310-cp310-win_amd64`, containing `xms/core/_xmscore.cp310-win_amd64.pyd`

716 passed, 2 skipped. `flake8` clean. `vs2019_build.py` at 100% line and branch.

## Known sharp edge, deliberately not fixed here

`collect_dependency_libs` walks the entire Conan cache and copies every `.dll` it finds — 795 of them on the test machine. On a box that is both the VS2019 build machine and a normal msvc 194 dev machine, that stages DLLs from both toolchains into `wheelhouse/libs`. `delvewheel` only vendors what the wheel actually imports, so it is usually harmless, but a same-named DLL from the wrong ABI could be picked.

Narrowing it (e.g. to `compiler.version=192` packages) is a `packager.py` change, which is shared with CI and wants a CI-aware decision. Documented as a caveat in `docs/USAGE.md` §16.8 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
